### PR TITLE
Make the CodeBlockParser extensible to support other languages in subclasses

### DIFF
--- a/sybil/parsers/codeblock.py
+++ b/sybil/parsers/codeblock.py
@@ -3,11 +3,11 @@ import textwrap
 
 from sybil import Region
 
-RE_CODEBLOCK_START = (
-    r'^(?P<indent>[ \t]*)\.\.\s*(invisible-)?code(-block)?::?\s*{{BLOCKLANGUAGE}}\b'
+CODEBLOCK_START = re.compile(
+    r'^(?P<indent>[ \t]*)\.\.\s*(invisible-)?code(-block)?::?\s*(?P<language>[\w-]+)\b'
     r'(?:\s*\:[\w-]+\:.*\n)*'
-    r'(?:\s*\n)*'
-)
+    r'(?:\s*\n)*',
+    re.MULTILINE)
 
 
 def compile_codeblock(source, path):
@@ -30,34 +30,30 @@ class CodeBlockParser(object):
         An optional list of strings that will be turned into
         ``from __future__ import ...`` statements and prepended to the code
         in each of the examples found by this parser.
-
-    Subclasses can override the language handled by this parser as follows.
-
-    - Overwrite the `LANGUAGE` attribute with the name of the language.
-
-    - Implement the `evaluation_function()` method to return an evaluation
-      function for that language.  The function will receive a
-      :class:`~sybil.example.Example` object as only argument, containing the
-      code that was parsed from the code block section.
     """
 
-    LANGUAGE = 'python'
+    _LANGUAGES = {
+        'python': evaluate_code_block,
+    }
+
+    @classmethod
+    def add_evaluator(cls, language, eval_function):
+        """
+        Adds (or overwrites) an evaluator function for the language.
+        """
+        cls._LANGUAGES[language] = eval_function
 
     def __init__(self, future_imports=()):
         self.future_imports = future_imports
-        self.block_start = re.compile(
-            RE_CODEBLOCK_START.replace('{{BLOCKLANGUAGE}}', self.LANGUAGE),
-            re.MULTILINE,
-        )
-
-    @staticmethod
-    def evaluation_function():
-        return evaluate_code_block
 
     def __call__(self, document):
-        evaluator_function = self.evaluation_function()
+        for start_match in re.finditer(CODEBLOCK_START, document.text):
+            language = start_match.group('language')
+            try:
+                evaluator_function = self._LANGUAGES[language]
+            except KeyError:
+                continue
 
-        for start_match in re.finditer(self.block_start, document.text):
             source_start = start_match.end()
             indent = str(len(start_match.group('indent')))
             end_pattern = re.compile(r'(\n\Z|\n[ \t]{0,'+indent+'}(?=\\S))')
@@ -67,7 +63,7 @@ class CodeBlockParser(object):
             # There must be a nicer way to get code.co_firstlineno
             # to be correct...
             line_count = document.text.count('\n', 0, source_start)
-            if self.future_imports:
+            if language == 'python' and self.future_imports:
                 line_count -= 1
                 source = 'from __future__ import {}\n{}'.format(
                     ', '.join(self.future_imports), source

--- a/tests/samples/codeblock.txt
+++ b/tests/samples/codeblock.txt
@@ -42,6 +42,15 @@ This paranoidly checks that we can use binary and unicode literals:
 
 - A following bullet straight away!
 
+- A code block in a non-python language:
+
+  .. code-block:: lolcode
+
+    HAI
+    CAN HAS STDIO?
+    VISIBLE "HAI WORLD!"
+    KTHXBYE
+
 - Here's another code block that should still be found!:
 
   .. code-block:: python

--- a/tests/samples/codeblock_future_imports.txt
+++ b/tests/samples/codeblock_future_imports.txt
@@ -7,3 +7,10 @@ More likely is one down here:
 .. code-block:: python
 
   print('still should work and have good line numbers', file=buffer)
+
+.. code-block:: lolcode
+
+   HAI
+   CAN HAS STDIO?
+   VISIBLE "HAI WORLD!"
+   KTHXBYE

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -9,8 +9,8 @@ from tests.helpers import document_from_sample, evaluate_region
 @pytest.fixture
 def loltest_cleanup():
     yield
-    if 'loltest' in CodeBlockParser._LANGUAGES:
-        del CodeBlockParser._LANGUAGES['loltest']
+    if 'lolcode' in CodeBlockParser._LANGUAGES:
+        del CodeBlockParser._LANGUAGES['lolcode']
 
 
 @pytest.mark.parametrize('languages', ['python', 'python,lolcode'])
@@ -61,7 +61,7 @@ def test_basic(languages, loltest_cleanup):
 def test_future_imports():
     document = document_from_sample('codeblock_future_imports.txt')
     regions = list(CodeBlockParser(['print_function'])(document))
-    assert len(regions) == 3
+    assert len(regions) == 2
     buffer = StringIO()
     namespace = {'buffer': buffer}
     assert evaluate_region(regions[0], namespace) is None
@@ -79,8 +79,6 @@ def test_future_imports():
     # the future import line drops the firstlineno by 1
     code = compile_codeblock(regions[1].parsed, document.path)
     assert code.co_firstlineno == 8
-
-    assert evaluate_region(regions[2], namespace) is None
 
 
 def test_windows_line_endings(tmp_path):


### PR DESCRIPTION
I would like to add Cython support, which is basically Python with a different evaluation function.

Given the `bash` example in the documentation, it seems to me that many if not most languages could be supported in this way, without requiring users to implement an actual parser.