### PR TITLE
Restore sorting of test paths to make tests reliable again

### DIFF
--- a/sybil/integration/unittest.py
+++ b/sybil/integration/unittest.py
@@ -38,7 +38,7 @@ def unittest_integration(sybil: 'Sybil'):
 
     def load_tests(loader=None, tests=None, pattern=None):
         suite = TestSuite()
-        for path in sybil.path.glob('**/*'):
+        for path in sorted(sybil.path.glob('**/*')):
             if path.is_file() and sybil.should_parse(path):
                 document = sybil.parse(path)
 

--- a/tests/test_sybil.py
+++ b/tests/test_sybil.py
@@ -243,7 +243,7 @@ def parse(document):
 
 def test_namespace(capsys):
     sybil = Sybil([parse], path='./samples')
-    documents = [sybil.parse(p) for p in sybil.path.glob('sample*.txt')]
+    documents = [sybil.parse(p) for p in sorted(sybil.path.glob('sample*.txt'))]
     actual = []
     for document in documents:
         for example in document:


### PR DESCRIPTION
11496eb5761761b687ad4889b4173d3124caa844 has replaced the all_documents
method with a direct call to glob.  This has implicitly resulted
in removal of path sorting that in turn means that the test output
depends on filesystem order now and is no longer reliable.
In particular, the tests can now fail randomly depending
on the underlying filesystem, unpack/checkout order, etc.  Restore
explicit sorting to make test order predictable again.

Fixes #34