### PR TITLE
Use stdlib inspect to get the caller filename

### DIFF
--- a/sybil/sybil.py
+++ b/sybil/sybil.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 from pathlib import Path
 from typing import Sequence, Callable, Collection, Mapping, Optional, Type, List
@@ -92,8 +93,10 @@ class Sybil:
     ):
 
         self.parsers: Sequence[Parser] = parsers
-        calling_filename = sys._getframe(1).f_globals.get('__file__')
-        if calling_filename:
+        current_frame = inspect.currentframe()
+        if current_frame is not None:
+            calling_frame = current_frame.f_back
+            calling_filename = inspect.getframeinfo(calling_frame).filename
             start_path = Path(calling_filename).parent / path
         else:
             start_path = Path(path)

--- a/sybil/sybil.py
+++ b/sybil/sybil.py
@@ -94,12 +94,9 @@ class Sybil:
 
         self.parsers: Sequence[Parser] = parsers
         current_frame = inspect.currentframe()
-        if current_frame is not None:
-            calling_frame = current_frame.f_back
-            calling_filename = inspect.getframeinfo(calling_frame).filename
-            start_path = Path(calling_filename).parent / path
-        else:
-            start_path = Path(path)
+        calling_frame = current_frame.f_back
+        calling_filename = inspect.getframeinfo(calling_frame).filename
+        start_path = Path(calling_filename).parent / path
         self.path: Path = start_path.absolute()
         self.patterns = list(patterns)
         if pattern:


### PR DESCRIPTION
`sys._getframe` is an off-label use (and might return `None` in some cases), stdlib inspect has the public APIs