### PR TITLE
Make all optional types explicit

### DIFF
--- a/sybil/parsers/abstract/codeblock.py
+++ b/sybil/parsers/abstract/codeblock.py
@@ -27,7 +27,7 @@ class AbstractCodeBlockParser:
 
     language: str
 
-    def __init__(self, lexers: Sequence[Lexer], language: str = None, evaluator: Evaluator = None):
+    def __init__(self, lexers: Sequence[Lexer], language: Optional[str] = None, evaluator: Optional[Evaluator] = None):
         self.lexers = lexers
         if language is not None:
             self.language = language

--- a/sybil/parsers/abstract/lexers.py
+++ b/sybil/parsers/abstract/lexers.py
@@ -1,6 +1,6 @@
 import re
 import textwrap
-from typing import Dict, Iterable, Pattern
+from typing import Optional, Dict, Iterable, Pattern
 
 from sybil import Document
 from sybil.region import LexedRegion, Lexeme
@@ -40,7 +40,7 @@ class BlockLexer:
             self,
             start_pattern: Pattern,
             end_pattern_template: str,
-            mapping: Dict[str, str] = None,
+            mapping: Optional[Dict[str, str]] = None,
     ):
         self.start_pattern = start_pattern
         self.end_pattern_template = end_pattern_template

--- a/sybil/parsers/myst/codeblock.py
+++ b/sybil/parsers/myst/codeblock.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Optional, Iterable
 
 from sybil.evaluators.python import PythonEvaluator
 from sybil.parsers.abstract import AbstractCodeBlockParser, DocTestStringParser
@@ -23,7 +23,7 @@ class CodeBlockParser(AbstractCodeBlockParser):
         You can also override the :meth:`evaluate` method below.
     """
 
-    def __init__(self, language: str = None, evaluator: Evaluator = None):
+    def __init__(self, language: Optional[str] = None, evaluator: Optional[Evaluator] = None):
         super().__init__(
             [
                 FencedCodeBlockLexer(

--- a/sybil/parsers/myst/lexers.py
+++ b/sybil/parsers/myst/lexers.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict
+from typing import Optional, Dict
 
 from sybil.parsers.abstract.lexers import BlockLexer
 
@@ -26,7 +26,7 @@ class FencedCodeBlockLexer(BlockLexer):
 
     """
 
-    def __init__(self, language: str, mapping: Dict[str, str] = None):
+    def __init__(self, language: str, mapping: Optional[Dict[str, str]] = None):
         super().__init__(
             start_pattern=re.compile(CODEBLOCK_START_TEMPLATE.format(language=language)),
             end_pattern_template=CODEBLOCK_END_TEMPLATE,
@@ -77,7 +77,7 @@ class DirectiveLexer(BlockLexer):
 
     """
 
-    def __init__(self, directive: str, arguments: str = '', mapping: Dict[str, str] = None):
+    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None):
         super().__init__(
             start_pattern=re.compile(
                 DIRECTIVE_START_TEMPLATE.format(directive=directive, arguments=arguments),
@@ -122,7 +122,7 @@ class DirectiveInPercentCommentLexer(BlockLexer):
         Only mapped lexemes will be returned in any :class:`~sybil.LexedRegion` objects.
     """
 
-    def __init__(self, directive: str, arguments: str = '', mapping: Dict[str, str] = None):
+    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None):
         super().__init__(
             start_pattern=re.compile(
                 DIRECTIVE_IN_PERCENT_COMMENT_START.format(directive=directive, arguments=arguments),
@@ -169,7 +169,7 @@ class DirectiveInHTMLCommentLexer(BlockLexer):
         Only mapped lexemes will be returned in any :class:`~sybil.LexedRegion` objects.
     """
 
-    def __init__(self, directive: str, arguments: str = '', mapping: Dict[str, str] = None):
+    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None):
         super().__init__(
             start_pattern=re.compile(
                 DIRECTIVE_IN_HTML_COMMENT_START.format(directive=directive, arguments=arguments),

--- a/sybil/parsers/rest/codeblock.py
+++ b/sybil/parsers/rest/codeblock.py
@@ -2,6 +2,7 @@ from sybil.evaluators.python import pad, PythonEvaluator
 from sybil.parsers.abstract import AbstractCodeBlockParser
 from sybil.parsers.rest.lexers import DirectiveLexer, DirectiveInCommentLexer
 from sybil.typing import Evaluator
+from typing import Optional
 
 
 class CodeBlockParser(AbstractCodeBlockParser):
@@ -16,7 +17,7 @@ class CodeBlockParser(AbstractCodeBlockParser):
         You can also override the :meth:`evaluate` method below.
     """
 
-    def __init__(self, language: str = None, evaluator: Evaluator = None):
+    def __init__(self, language: Optional[str] = None, evaluator: Optional[Evaluator] = None):
         super().__init__(
             [
                 DirectiveLexer(directive=r'code-block'),

--- a/sybil/parsers/rest/lexers.py
+++ b/sybil/parsers/rest/lexers.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict
+from typing import Optional, Dict
 
 from sybil.parsers.abstract.lexers import BlockLexer
 
@@ -36,7 +36,7 @@ class DirectiveLexer(BlockLexer):
 
     delimiter = '::'
 
-    def __init__(self, directive: str, arguments: str = '', mapping: Dict[str, str] = None):
+    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None):
         """
         A lexer for ReST directives.
         Both ``directive`` and ``arguments`` are regex patterns.

--- a/sybil/sybil.py
+++ b/sybil/sybil.py
@@ -79,17 +79,17 @@ class Sybil:
     def __init__(
         self,
         parsers: Sequence[Parser],
-        pattern: str = None,
+        pattern: Optional[str] = None,
         patterns: Sequence[str] = (),
-        exclude: str = None,
+        exclude: Optional[str] = None,
         excludes: Sequence[str] = (),
         filenames: Collection[str] = (),
         path: str = '.',
-        setup: Callable[[dict], None] = None,
-        teardown: Callable[[dict], None] = None,
+        setup: Optional[Callable[[dict], None]] = None,
+        teardown: Optional[Callable[[dict], None]] = None,
         fixtures: Sequence[str] = (),
         encoding: str = 'utf-8',
-        document_types: Mapping[Optional[str], Type[Document]] = None
+        document_types: Optional[Mapping[Optional[str], Type[Document]]] = None
     ):
 
         self.parsers: Sequence[Parser] = parsers

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,7 +7,7 @@ from shutil import copytree
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 from traceback import TracebackException
-from typing import Tuple, List, Sequence
+from typing import Optional, Tuple, List, Sequence
 from unittest import TextTestRunner, main as unittest_main
 
 import pytest
@@ -131,7 +131,7 @@ class Results:
 
     def __init__(
         self, capsys: CaptureFixture[str], total: int, errors: int = 0, failures: int = 0,
-        return_code: int = None,
+        return_code: Optional[int] = None,
     ):
         self.total = total
         self.errors = errors


### PR DESCRIPTION
This is one step towards having type safety.

This is the result of running https://github.com/hauntsaninja/no_implicit_optional against `sybil/` and `tests/`.

My thinking in separating this out is that type hinting is a ~large project which:

* I don't want to commit to finishing right now
* Can quickly get annoyingly conflict-y with `master` as it touches many files