### PR TITLE
Resolve all mypy no-untyped-def errors which require "-> None"

### DIFF
--- a/sybil/document.py
+++ b/sybil/document.py
@@ -33,7 +33,7 @@ class Document:
     #: This last case should always take the form of ``example.region.evaluator(example)``.
     evaluator: Evaluator = None
 
-    def __init__(self, text: str, path: str):
+    def __init__(self, text: str, path: str) -> None:
         #: This is the text of the documentation source file.
         self.text: str = text
         #: This is the absolute path of the documentation source file.

--- a/sybil/evaluators/doctest.py
+++ b/sybil/evaluators/doctest.py
@@ -8,7 +8,7 @@ from sybil import Example
 
 
 class DocTest(BaseDocTest):
-    def __init__(self, examples, globs, name, filename, lineno, docstring):
+    def __init__(self, examples, globs, name, filename, lineno, docstring) -> None:
         # do everything like regular doctests, but don't make a copy of globs
         BaseDocTest.__init__(self, examples, globs, name, filename, lineno, docstring)
         self.globs = globs
@@ -16,7 +16,7 @@ class DocTest(BaseDocTest):
 
 class DocTestRunner(BaseDocTestRunner):
 
-    def __init__(self, optionflags):
+    def __init__(self, optionflags) -> None:
         optionflags |= _unittest_reportflags
         BaseDocTestRunner.__init__(
             self,
@@ -39,7 +39,7 @@ class DocTestEvaluator:
         when evaluating examples.
     """
 
-    def __init__(self, optionflags=0):
+    def __init__(self, optionflags=0) -> None:
         self.runner = DocTestRunner(optionflags)
 
     def __call__(self, sybil_example: Example) -> str:

--- a/sybil/evaluators/python.py
+++ b/sybil/evaluators/python.py
@@ -15,7 +15,7 @@ def pad(source: str, line: int) -> str:
 
 class PythonEvaluator:
 
-    def __init__(self, future_imports: Sequence[str] = ()):
+    def __init__(self, future_imports: Sequence[str] = ()) -> None:
         self.flags = 0
         for future_import in future_imports:
             self.flags |= getattr(__future__, future_import).compiler_flag

--- a/sybil/evaluators/skip.py
+++ b/sybil/evaluators/skip.py
@@ -5,7 +5,7 @@ from sybil import Example
 
 class If:
 
-    def __init__(self, default_reason):
+    def __init__(self, default_reason) -> None:
         self.default_reason = default_reason
 
     def __call__(self, condition, reason=None):
@@ -15,7 +15,7 @@ class If:
 
 class Skip:
 
-    def __init__(self, original_evaluator):
+    def __init__(self, original_evaluator) -> None:
         self.original_evaluator = original_evaluator
         self.restore_next = False
         self.reason = None

--- a/sybil/example.py
+++ b/sybil/example.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class SybilFailure(AssertionError):
 
-    def __init__(self, example: 'Example', result: str):
+    def __init__(self, example: 'Example', result: str) -> None:
         super(SybilFailure, self).__init__((
             'Example at {}, line {}, column {} did not evaluate as expected:\n'
             '{}'
@@ -27,7 +27,7 @@ class Example:
 
     def __init__(
         self, document: 'Document', line: int, column: int, region: Region, namespace: dict
-    ):
+    ) -> None:
         #: The :class:`~sybil.document.Document` from which this example came.
         self.document: 'Document' = document
         #: The absolute path of the :class:`~sybil.document.Document`.

--- a/sybil/integration/pytest.py
+++ b/sybil/integration/pytest.py
@@ -27,7 +27,7 @@ example_module_path = abspath(getsourcefile(example))
 
 class SybilFailureRepr(TerminalRepr):
 
-    def __init__(self, item, message):
+    def __init__(self, item, message) -> None:
         self.item = item
         self.message = message
 
@@ -42,7 +42,7 @@ class SybilFailureRepr(TerminalRepr):
 
 class SybilItem(pytest.Item):
 
-    def __init__(self, parent, sybil, example):
+    def __init__(self, parent, sybil, example) -> None:
         name = 'line:{},column:{}'.format(example.line, example.column)
         super(SybilItem, self).__init__(name, parent)
         self.example = example
@@ -70,12 +70,12 @@ class SybilItem(pytest.Item):
         if cls is Session:
             return self.session
 
-    def setup(self):
+    def setup(self) -> None:
         self._request._fillfixtures()
         for name, fixture in self.funcargs.items():
             self.example.namespace[name] = fixture
 
-    def runtest(self):
+    def runtest(self) -> None:
         self.example.evaluate()
 
     if PYTEST_VERSION >= (7, 4, 0):
@@ -108,7 +108,7 @@ class SybilItem(pytest.Item):
 
 class SybilFile(pytest.File):
 
-    def __init__(self, *, sybil: 'Sybil', **kwargs):
+    def __init__(self, *, sybil: 'Sybil', **kwargs) -> None:
         super(SybilFile, self).__init__(**kwargs)
         self.sybil: 'Sybil' = sybil
 
@@ -117,11 +117,11 @@ class SybilFile(pytest.File):
         for example in self.document:
             yield SybilItem.from_parent(self, sybil=self.sybil, example=example)
 
-    def setup(self):
+    def setup(self) -> None:
         if self.sybil.setup:
             self.sybil.setup(self.document.namespace)
 
-    def teardown(self):
+    def teardown(self) -> None:
         if self.sybil.teardown:
             self.sybil.teardown(self.document.namespace)
 

--- a/sybil/integration/unittest.py
+++ b/sybil/integration/unittest.py
@@ -9,11 +9,11 @@ class TestCase(BaseTestCase):
 
     sybil = namespace = None
 
-    def __init__(self, example):
+    def __init__(self, example) -> None:
         BaseTestCase.__init__(self)
         self.example = example
 
-    def runTest(self):
+    def runTest(self) -> None:
         self.example.evaluate()
 
     def id(self):
@@ -24,12 +24,12 @@ class TestCase(BaseTestCase):
     __str__ = __repr__ = id
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         if cls.sybil.setup is not None:
             cls.sybil.setup(cls.namespace)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         if cls.sybil.teardown is not None:
             cls.sybil.teardown(cls.namespace)
 

--- a/sybil/parsers/abstract/clear.py
+++ b/sybil/parsers/abstract/clear.py
@@ -9,7 +9,7 @@ class AbstractClearNamespaceParser:
     An abstract parser for clearing the :class:`~sybil.Document.namespace`.
     """
 
-    def __init__(self, lexer: Lexer):
+    def __init__(self, lexer: Lexer) -> None:
         self.lexer = lexer
 
     @staticmethod

--- a/sybil/parsers/abstract/codeblock.py
+++ b/sybil/parsers/abstract/codeblock.py
@@ -27,7 +27,7 @@ class AbstractCodeBlockParser:
 
     language: str
 
-    def __init__(self, lexers: Sequence[Lexer], language: Optional[str] = None, evaluator: Optional[Evaluator] = None):
+    def __init__(self, lexers: Sequence[Lexer], language: Optional[str] = None, evaluator: Optional[Evaluator] = None) -> None:
         self.lexers = lexers
         if language is not None:
             self.language = language

--- a/sybil/parsers/abstract/doctest.py
+++ b/sybil/parsers/abstract/doctest.py
@@ -14,7 +14,7 @@ class DocTestStringParser(BaseDocTestParser):
     the doctest example's source and the file name that the example came from.
     """
 
-    def __init__(self, evaluator: DocTestEvaluator = DocTestEvaluator()):
+    def __init__(self, evaluator: DocTestEvaluator = DocTestEvaluator()) -> None:
         #: The evaluator to use for any doctests found in the supplied source string.
         self.evaluator: DocTestEvaluator = evaluator
 

--- a/sybil/parsers/abstract/lexers.py
+++ b/sybil/parsers/abstract/lexers.py
@@ -41,7 +41,7 @@ class BlockLexer:
             start_pattern: Pattern,
             end_pattern_template: str,
             mapping: Optional[Dict[str, str]] = None,
-    ):
+    ) -> None:
         self.start_pattern = start_pattern
         self.end_pattern_template = end_pattern_template
         self.mapping = mapping

--- a/sybil/parsers/myst/clear.py
+++ b/sybil/parsers/myst/clear.py
@@ -9,5 +9,5 @@ class ClearNamespaceParser(AbstractClearNamespaceParser):
     A :any:`Parser` for :ref:`clear-namespace <myst-clear-namespace>` instructions.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(DirectiveInPercentCommentLexer('clear-namespace'))

--- a/sybil/parsers/myst/codeblock.py
+++ b/sybil/parsers/myst/codeblock.py
@@ -23,7 +23,7 @@ class CodeBlockParser(AbstractCodeBlockParser):
         You can also override the :meth:`evaluate` method below.
     """
 
-    def __init__(self, language: Optional[str] = None, evaluator: Optional[Evaluator] = None):
+    def __init__(self, language: Optional[str] = None, evaluator: Optional[Evaluator] = None) -> None:
         super().__init__(
             [
                 FencedCodeBlockLexer(
@@ -63,7 +63,7 @@ class PythonCodeBlockParser(CodeBlockParser):
 
     language = 'python'
 
-    def __init__(self, future_imports=(), doctest_optionflags=0):
+    def __init__(self, future_imports=(), doctest_optionflags=0) -> None:
         super().__init__(evaluator=PythonEvaluator(future_imports))
         self.doctest_parser = DocTestStringParser(DocTestEvaluator(doctest_optionflags))
 

--- a/sybil/parsers/myst/doctest.py
+++ b/sybil/parsers/myst/doctest.py
@@ -15,7 +15,7 @@ class DocTestDirectiveParser(DirectiveLexer):
         when evaluating the examples found by this parser.
 
     """
-    def __init__(self, optionflags=0):
+    def __init__(self, optionflags=0) -> None:
         super().__init__('doctest')
         self.string_parser = DocTestStringParser(DocTestEvaluator(optionflags))
 

--- a/sybil/parsers/myst/lexers.py
+++ b/sybil/parsers/myst/lexers.py
@@ -26,7 +26,7 @@ class FencedCodeBlockLexer(BlockLexer):
 
     """
 
-    def __init__(self, language: str, mapping: Optional[Dict[str, str]] = None):
+    def __init__(self, language: str, mapping: Optional[Dict[str, str]] = None) -> None:
         super().__init__(
             start_pattern=re.compile(CODEBLOCK_START_TEMPLATE.format(language=language)),
             end_pattern_template=CODEBLOCK_END_TEMPLATE,
@@ -77,7 +77,7 @@ class DirectiveLexer(BlockLexer):
 
     """
 
-    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None):
+    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None) -> None:
         super().__init__(
             start_pattern=re.compile(
                 DIRECTIVE_START_TEMPLATE.format(directive=directive, arguments=arguments),
@@ -122,7 +122,7 @@ class DirectiveInPercentCommentLexer(BlockLexer):
         Only mapped lexemes will be returned in any :class:`~sybil.LexedRegion` objects.
     """
 
-    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None):
+    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None) -> None:
         super().__init__(
             start_pattern=re.compile(
                 DIRECTIVE_IN_PERCENT_COMMENT_START.format(directive=directive, arguments=arguments),
@@ -169,7 +169,7 @@ class DirectiveInHTMLCommentLexer(BlockLexer):
         Only mapped lexemes will be returned in any :class:`~sybil.LexedRegion` objects.
     """
 
-    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None):
+    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None) -> None:
         super().__init__(
             start_pattern=re.compile(
                 DIRECTIVE_IN_HTML_COMMENT_START.format(directive=directive, arguments=arguments),

--- a/sybil/parsers/rest/capture.py
+++ b/sybil/parsers/rest/capture.py
@@ -30,7 +30,7 @@ def indent_matches(line, indent):
 
 class DocumentReverseIterator(list):
 
-    def __init__(self, document):
+    def __init__(self, document) -> None:
         self[:] = document.text.splitlines(keepends=True)
         self.current_line = len(self)
         self.current_line_end_position = len(document.text)

--- a/sybil/parsers/rest/clear.py
+++ b/sybil/parsers/rest/clear.py
@@ -9,5 +9,5 @@ class ClearNamespaceParser(AbstractClearNamespaceParser):
     A :any:`Parser` for :ref:`clear-namespace <clear-namespace>` instructions.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(DirectiveInCommentLexer('clear-namespace'))

--- a/sybil/parsers/rest/codeblock.py
+++ b/sybil/parsers/rest/codeblock.py
@@ -17,7 +17,7 @@ class CodeBlockParser(AbstractCodeBlockParser):
         You can also override the :meth:`evaluate` method below.
     """
 
-    def __init__(self, language: Optional[str] = None, evaluator: Optional[Evaluator] = None):
+    def __init__(self, language: Optional[str] = None, evaluator: Optional[Evaluator] = None) -> None:
         super().__init__(
             [
                 DirectiveLexer(directive=r'code-block'),
@@ -39,5 +39,5 @@ class PythonCodeBlockParser(CodeBlockParser):
         in each of the examples found by this parser.
     """
 
-    def __init__(self, future_imports=()):
+    def __init__(self, future_imports=()) -> None:
         super().__init__(language='python', evaluator=PythonEvaluator(future_imports))

--- a/sybil/parsers/rest/doctest.py
+++ b/sybil/parsers/rest/doctest.py
@@ -15,7 +15,7 @@ class DocTestParser:
         when evaluating the examples found by this parser.
 
     """
-    def __init__(self, optionflags=0):
+    def __init__(self, optionflags=0) -> None:
         self.string_parser = DocTestStringParser(DocTestEvaluator(optionflags))
 
     def __call__(self, document: Document) -> Iterable[Region]:
@@ -32,7 +32,7 @@ class DocTestDirectiveParser:
 
     """
 
-    def __init__(self, optionflags=0):
+    def __init__(self, optionflags=0) -> None:
         self.lexer = DirectiveLexer(directive='doctest')
         self.string_parser = DocTestStringParser(DocTestEvaluator(optionflags))
 

--- a/sybil/parsers/rest/lexers.py
+++ b/sybil/parsers/rest/lexers.py
@@ -36,7 +36,7 @@ class DirectiveLexer(BlockLexer):
 
     delimiter = '::'
 
-    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None):
+    def __init__(self, directive: str, arguments: str = '', mapping: Optional[Dict[str, str]] = None) -> None:
         """
         A lexer for ReST directives.
         Both ``directive`` and ``arguments`` are regex patterns.

--- a/sybil/region.py
+++ b/sybil/region.py
@@ -13,7 +13,7 @@ class Lexeme(str):
     def __new__(cls, text: str, offset, line_offset: int):
         return str.__new__(cls, text)
 
-    def __init__(self, text: str, offset, line_offset: int):
+    def __init__(self, text: str, offset, line_offset: int) -> None:
         self.text, self.offset, self.line_offset = text, offset, line_offset
 
 
@@ -23,7 +23,7 @@ class LexedRegion:
     parsed or assigned an :any:`Evaluator`.
     """
 
-    def __init__(self, start: int, end: int, lexemes: Dict[str, Union[str, Lexeme]]):
+    def __init__(self, start: int, end: int, lexemes: Dict[str, Union[str, Lexeme]]) -> None:
         #: The start of this lexed region within the document's :attr:`~sybil.Document.text`.
         self.start: int = start
         #: The end of this lexed region within the document's :attr:`~sybil.Document.text`.
@@ -31,7 +31,7 @@ class LexedRegion:
         #: The lexemes extracted from the region.
         self.lexemes: Dict[str, Union[str, Lexeme]] = lexemes
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         lexemes_for_repr = {}
         for name, lexeme in self.lexemes.items():
             if lexeme and len(lexeme) > 10:
@@ -61,7 +61,7 @@ class Region:
         as it should be.
     """
 
-    def __init__(self, start: int, end: int, parsed: Any, evaluator: Evaluator):
+    def __init__(self, start: int, end: int, parsed: Any, evaluator: Evaluator) -> None:
         #: The start of this region within the document's :attr:`~sybil.Document.text`.
         self.start: int = start
         #: The end of this region within the document's :attr:`~sybil.Document.text`.

--- a/sybil/sybil.py
+++ b/sybil/sybil.py
@@ -90,7 +90,7 @@ class Sybil:
         fixtures: Sequence[str] = (),
         encoding: str = 'utf-8',
         document_types: Optional[Mapping[Optional[str], Type[Document]]] = None
-    ):
+    ) -> None:
 
         self.parsers: Sequence[Parser] = parsers
         current_frame = inspect.currentframe()

--- a/sybil/text.py
+++ b/sybil/text.py
@@ -5,7 +5,7 @@ NEWLINE = re.compile("\n")
 
 class LineNumberOffsets:
 
-    def __init__(self, text: str):
+    def __init__(self, text: str) -> None:
         self.offsets = {
             line: match.start()+1 for (line, match) in enumerate(NEWLINE.finditer(text), start=1)
         }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -105,7 +105,7 @@ TEST_OUTPUT_TEMPLATES = {
 
 class Finder:
 
-    def __init__(self, text):
+    def __init__(self, text) -> None:
         self.text = text
         self.index = 0
 
@@ -132,7 +132,7 @@ class Results:
     def __init__(
         self, capsys: CaptureFixture[str], total: int, errors: int = 0, failures: int = 0,
         return_code: Optional[int] = None,
-    ):
+    ) -> None:
         self.total = total
         self.errors = errors
         self.failures = failures

--- a/tests/samples/docstrings.py
+++ b/tests/samples/docstrings.py
@@ -1,4 +1,4 @@
-def r_prefixed_docstring():
+def r_prefixed_docstring() -> None:
     r"""
     Wat? Why?!
     """

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -7,7 +7,7 @@ from sybil.parsers.rest import CaptureParser
 from tests.helpers import sample_path, parse
 
 
-def test_basic():
+def test_basic() -> None:
     examples, namespace = parse('capture.txt', CaptureParser(), expected=4)
     examples[0].evaluate()
     assert namespace['expected_listing'] == (
@@ -29,7 +29,7 @@ def test_basic():
     )
 
 
-def test_directive_indent_beyond_block():
+def test_directive_indent_beyond_block() -> None:
     path = sample_path('capture_bad_indent1.txt')
     with pytest.raises(ValueError) as excinfo:
         Document.parse(path, CaptureParser())
@@ -39,7 +39,7 @@ def test_directive_indent_beyond_block():
         )
 
 
-def test_directive_indent_equal_to_block():
+def test_directive_indent_equal_to_block() -> None:
     path = sample_path('capture_bad_indent2.txt')
     with pytest.raises(ValueError) as excinfo:
         Document.parse(path, CaptureParser())
@@ -49,7 +49,7 @@ def test_directive_indent_equal_to_block():
         )
 
 
-def test_capture_codeblock():
+def test_capture_codeblock() -> None:
     examples, namespace = parse('capture_codeblock.txt', CaptureParser(), expected=1)
     examples[0].evaluate()
     assert json.loads(namespace['json']) == {"a key": "value", "b key": 42}

--- a/tests/test_clear.py
+++ b/tests/test_clear.py
@@ -2,7 +2,7 @@ from sybil.parsers.rest import ClearNamespaceParser, DocTestParser
 from .helpers import parse
 
 
-def test_basic():
+def test_basic() -> None:
     examples, namespace = parse('clear.txt', DocTestParser(), ClearNamespaceParser(), expected=4)
     for example in examples:
         example.evaluate()

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -11,7 +11,7 @@ from sybil.parsers.codeblock import PythonCodeBlockParser, CodeBlockParser
 from .helpers import check_excinfo, parse, sample_path, check_path, SAMPLE_PATH, add_to_python_path
 
 
-def test_basic():
+def test_basic() -> None:
     examples, namespace = parse('codeblock.txt', PythonCodeBlockParser(), expected=7)
     namespace['y'] = namespace['z'] = 0
     assert examples[0].evaluate() is None
@@ -37,7 +37,7 @@ def test_basic():
     assert '__builtins__' not in namespace
 
 
-def test_other_language_composition_pass():
+def test_other_language_composition_pass() -> None:
 
     def oh_hai(example):
         assert isinstance(example, Example)
@@ -48,7 +48,7 @@ def test_other_language_composition_pass():
     assert examples[0].evaluate() is None
 
 
-def test_other_language_composition_fail():
+def test_other_language_composition_fail() -> None:
     def oh_noez(example):
         if 'KTHXBYE' in example.parsed:
             raise ValueError('oh noez')
@@ -59,7 +59,7 @@ def test_other_language_composition_fail():
         examples[0].evaluate()
 
 
-def test_other_language_no_evaluator():
+def test_other_language_no_evaluator() -> None:
     parser = CodeBlockParser('foo')
     with pytest.raises(NotImplementedError):
         parser.evaluate(...)
@@ -74,7 +74,7 @@ class LolCodeCodeBlockParser(CodeBlockParser):
             raise ValueError(repr(example.parsed))
 
 
-def test_other_language_inheritance():
+def test_other_language_inheritance() -> None:
     examples, namespace = parse('codeblock_lolcode.txt', LolCodeCodeBlockParser(), expected=2)
     examples[0].evaluate()
     with pytest.raises(ValueError) as excinfo:
@@ -99,26 +99,26 @@ def future_import_checks(*future_imports):
     return namespace['foo']
 
 
-def test_no_future_imports():
+def test_no_future_imports() -> None:
     future_import_checks()
 
 
-def test_single_future_import():
+def test_single_future_import() -> None:
     future_import_checks('barry_as_FLUFL')
 
 
-def test_multiple_future_imports():
+def test_multiple_future_imports() -> None:
     future_import_checks('barry_as_FLUFL', 'print_function')
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
-def test_functional_future_imports():
+def test_functional_future_imports() -> None:
     foo = future_import_checks('annotations')
     # This will keep working but not be an effective test once PEP 563 finally lands:
     assert foo.__code__.co_flags & __future__.annotations.compiler_flag
 
 
-def test_windows_line_endings(tmp_path: Path):
+def test_windows_line_endings(tmp_path: Path) -> None:
     p = tmp_path / "example.txt"
     p.write_bytes(
         b'This is my example:\r\n\r\n'
@@ -133,7 +133,7 @@ def test_windows_line_endings(tmp_path: Path):
     assert document.namespace['x'] == 123
 
 
-def test_line_numbers_with_options():
+def test_line_numbers_with_options() -> None:
     parser = PythonCodeBlockParser()
     examples, namespace = parse('codeblock_with_options.txt', parser, expected=2)
     with pytest.raises(Exception) as excinfo:
@@ -146,7 +146,7 @@ def test_line_numbers_with_options():
     check_excinfo(examples[1], excinfo, 'Boom 2', lineno=14)
 
 
-def test_codeblocks_in_docstrings():
+def test_codeblocks_in_docstrings() -> None:
     sybil = Sybil([PythonCodeBlockParser()])
     with add_to_python_path(SAMPLE_PATH):
         check_path(sample_path('docstrings.py'), sybil, expected=3)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -7,7 +7,7 @@ from sybil.parsers.skip import skip
 from .helpers import parse
 
 
-def test_imports():
+def test_imports() -> None:
     # uncomment once all the moves are done!
     from sybil.parsers.capture import parse_captures
     from sybil.parsers.codeblock import CodeBlockParser, PythonCodeBlockParser
@@ -16,18 +16,18 @@ def test_imports():
     pass
 
 
-def test_code_block_parser_pad():
+def test_code_block_parser_pad() -> None:
     assert CodeBlockParser('foo').pad('x', line=2) == '\n\nx'
 
 
-def test_skip_parser_function():
+def test_skip_parser_function() -> None:
     examples, namespace = parse('skip.txt', PythonCodeBlockParser(), skip, expected=9)
     for example in examples:
         example.evaluate()
     assert namespace['run'] == [2, 5]
 
 
-def test_capture_parser_function():
+def test_capture_parser_function() -> None:
     examples, namespace = parse('capture_codeblock.txt', parse_captures, expected=1)
     examples[0].evaluate()
     assert json.loads(namespace['json']) == {"a key": "value", "b key": 42}

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -26,13 +26,13 @@ def pytest_in(*path: str):
 
 class TestIntegrationExamples:
 
-    def test_pytest(self):
+    def test_pytest(self) -> None:
         session = pytest_in('integration', 'docs')
         assert session.exitstatus == 0
         assert session.testsfailed == 0
         assert session.testscollected == 3
 
-    def test_unittest(self):
+    def test_unittest(self) -> None:
         runner = TextTestRunner(verbosity=2, stream=sys.stdout)
         path = str(DOC_EXAMPLES / 'integration' / 'unittest')
         main = unittest_main(
@@ -44,14 +44,14 @@ class TestIntegrationExamples:
         assert len(main.result.errors) == 0
 
 
-def test_quickstart():
+def test_quickstart() -> None:
     session = pytest_in('quickstart')
     assert session.exitstatus == 0
     assert session.testsfailed == 0
     assert session.testscollected == 4
 
 
-def test_rest_text_rest_src():
+def test_rest_text_rest_src() -> None:
     directory = 'rest_text_rest_src'
     with add_to_python_path(DOC_EXAMPLES / directory / 'src'):
         session = pytest_in(directory)
@@ -59,7 +59,7 @@ def test_rest_text_rest_src():
     assert session.testscollected == 5
 
 
-def test_myst_text_rest_src():
+def test_myst_text_rest_src() -> None:
     directory = 'myst_text_rest_src'
     with add_to_python_path(DOC_EXAMPLES / directory / 'src'):
         session = pytest_in(directory)

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -12,7 +12,7 @@ from sybil.parsers.rest import DocTestParser, DocTestDirectiveParser
 from .helpers import sample_path, parse, FUNCTIONAL_TEST_DIR, skip_if_37_or_older
 
 
-def test_pass():
+def test_pass() -> None:
     examples, namespace = parse('doctest.txt', DocTestParser(), expected=5)
     examples[0].evaluate()
     assert namespace['y'] == 1
@@ -26,7 +26,7 @@ def test_pass():
     assert namespace['y'] == 2
 
 
-def test_fail():
+def test_fail() -> None:
     path = sample_path('doctest_fail.txt')
     examples, namespace = parse('doctest_fail.txt', DocTestParser(), expected=2)
     with pytest.raises(SybilFailure) as excinfo:
@@ -48,7 +48,7 @@ def test_fail():
     assert actual.endswith('Exception: boom!\n')
 
 
-def test_fail_with_options():
+def test_fail_with_options() -> None:
     parser = DocTestParser(optionflags=REPORT_NDIFF|ELLIPSIS)
     examples, namespace = parse('doctest_fail.txt', parser, expected=2)
     with pytest.raises(SybilFailure) as excinfo:
@@ -60,36 +60,36 @@ def test_fail_with_options():
     )
 
 
-def test_literals():
+def test_literals() -> None:
     parser = DocTestParser()
     examples, _ = parse('doctest_literals.txt', parser, expected=5)
     for example in examples:
         example.evaluate()
 
 
-def test_min_indent():
+def test_min_indent() -> None:
     examples, _ = parse('doctest_min_indent.txt', DocTestParser(), expected=1)
     examples[0].evaluate()
 
 
-def test_tabs():
+def test_tabs() -> None:
     path = sample_path('doctest_tabs.txt')
     parser = DocTestParser()
     with pytest.raises(ValueError):
         Document.parse(path, parser)
 
 
-def test_irrelevant_tabs():
+def test_irrelevant_tabs() -> None:
     examples, _ = parse('doctest_irrelevant_tabs.txt', DocTestParser(), expected=1)
     examples[0].evaluate()
 
 
-def test_unicode():
+def test_unicode() -> None:
     examples, _ = parse('doctest_unicode.txt', DocTestParser(), expected=1)
     examples[0].evaluate()
 
 
-def test_directive():
+def test_directive() -> None:
     path = sample_path('doctest_directive.txt')
     examples, _ = parse('doctest_directive.txt', DocTestDirectiveParser(), expected=3)
     examples[0].evaluate()
@@ -109,7 +109,7 @@ def test_directive():
     assert actual.endswith('Exception: boom!\n')
 
 
-def test_directive_with_options():
+def test_directive_with_options() -> None:
     path = sample_path('doctest_directive.txt')
     parser = DocTestDirectiveParser(optionflags=REPORT_NDIFF|ELLIPSIS)
     examples, namespace = parse('doctest_directive.txt', parser, expected=3)
@@ -132,7 +132,7 @@ MINIMUM_EXPECTED_DOCTESTS = 9
 
 
 @skip_if_37_or_older()
-def test_sybil_example_count(all_python_files):
+def test_sybil_example_count(all_python_files) -> None:
     parser = DocTestStringParser()
 
     seen_examples_from_source = 0
@@ -170,7 +170,7 @@ def check_sybil_against_doctest(path, text):
         raise AssertionError('doctests not correctly extracted:\n\n'+'\n\n'.join(problems))
 
 
-def test_all_docstest_examples_extracted_from_source_correctly(python_file):
+def test_all_docstest_examples_extracted_from_source_correctly(python_file) -> None:
     path, source = python_file
     if path in UNPARSEABLE:
         return
@@ -178,7 +178,7 @@ def test_all_docstest_examples_extracted_from_source_correctly(python_file):
 
 
 @skip_if_37_or_older()
-def test_all_docstest_examples_extracted_from_docstrings_correctly(python_file):
+def test_all_docstest_examples_extracted_from_docstrings_correctly(python_file) -> None:
     path, source = python_file
     for start, end, docstring in PythonDocStringDocument.extract_docstrings(source):
         check_sybil_against_doctest(path, docstring)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -11,7 +11,7 @@ from .helpers import ast_docstrings, skip_if_37_or_older
 
 
 @skip_if_37_or_older()
-def test_extract_docstring():
+def test_extract_docstring() -> None:
     """
     This is a function docstring.
     """
@@ -23,7 +23,7 @@ def test_extract_docstring():
 
 
 @skip_if_37_or_older()
-def test_all_docstrings_extracted_correctly(python_file):
+def test_all_docstrings_extracted_correctly(python_file) -> None:
     problems = []
     path, source = python_file
     expected = list(ast_docstrings(source))

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -19,7 +19,7 @@ def cleanup_imports():
         yield
 
 
-def test_pytest(capsys: CaptureFixture[str]):
+def test_pytest(capsys: CaptureFixture[str]) -> None:
     results = run_pytest(capsys, functional_sample('pytest'))
     out = results.out
 
@@ -101,7 +101,7 @@ def test_pytest(capsys: CaptureFixture[str]):
     assert results.total == 10
 
 
-def test_unittest(capsys: CaptureFixture[str]):
+def test_unittest(capsys: CaptureFixture[str]) -> None:
     results = run_unittest(capsys, functional_sample('unittest'))
     out = results.out
     out.then_find('sybil setup')
@@ -138,7 +138,7 @@ def make_tree(tmpdir: local) -> None:
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_everything(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_everything(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     make_tree(tmpdir)
     write_config(tmpdir, runner)
     results = run(capsys, runner, tmpdir)
@@ -147,7 +147,7 @@ def test_filter_everything(tmpdir: local, capsys: CaptureFixture[str], runner: s
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_just_pattern(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_just_pattern(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     make_tree(tmpdir)
     write_config(tmpdir, runner, pattern="'*.rst'")
     results = run(capsys, runner, tmpdir)
@@ -155,7 +155,7 @@ def test_filter_just_pattern(tmpdir: local, capsys: CaptureFixture[str], runner:
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_fnmatch_pattern(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_fnmatch_pattern(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     make_tree(tmpdir)
     write_config(tmpdir, runner, pattern="'**/*.rst'")
     results = run(capsys, runner, tmpdir)
@@ -169,7 +169,7 @@ def test_filter_fnmatch_pattern(tmpdir: local, capsys: CaptureFixture[str], runn
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_just_filenames(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_just_filenames(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     make_tree(tmpdir)
     write_config(tmpdir, runner,
                  filenames="['bar.rst']")
@@ -181,7 +181,7 @@ def test_filter_just_filenames(tmpdir: local, capsys: CaptureFixture[str], runne
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_directory(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_directory(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     make_tree(tmpdir)
     write_config(tmpdir, runner,
                  path=f"'{tmpdir / 'parent'}'",
@@ -195,7 +195,7 @@ def test_filter_directory(tmpdir: local, capsys: CaptureFixture[str], runner: st
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_directory_with_excludes(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_directory_with_excludes(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     make_tree(tmpdir)
     write_config(tmpdir, runner,
                  path=f"'{tmpdir / 'parent'}'",
@@ -208,7 +208,7 @@ def test_filter_directory_with_excludes(tmpdir: local, capsys: CaptureFixture[st
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_filenames_and_excludes(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_filenames_and_excludes(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     make_tree(tmpdir)
     write_config(tmpdir, runner,
                  path=f"'{tmpdir / 'parent'}'",
@@ -220,7 +220,7 @@ def test_filter_filenames_and_excludes(tmpdir: local, capsys: CaptureFixture[str
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_exclude_by_name(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_exclude_by_name(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     write_doctest(tmpdir, 'foo.txt')
     write_doctest(tmpdir, 'bar.txt')
     write_doctest(tmpdir, 'child', 'foo.txt')
@@ -235,7 +235,7 @@ def test_filter_exclude_by_name(tmpdir: local, capsys: CaptureFixture[str], runn
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_include_filenames(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_include_filenames(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     write_doctest(tmpdir, 'foo.txt')
     write_doctest(tmpdir, 'bar.txt')
     write_doctest(tmpdir, 'baz', 'bar.txt')
@@ -248,7 +248,7 @@ def test_filter_include_filenames(tmpdir: local, capsys: CaptureFixture[str], ru
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_globs(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_globs(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     write_doctest(tmpdir, 'middle', 'interesting', 'foo.txt')
     write_doctest(tmpdir, 'middle', 'boring', 'bad1.txt')
     write_doctest(tmpdir, 'middle', 'boring', 'bad2.txt')
@@ -261,7 +261,7 @@ def test_filter_globs(tmpdir: local, capsys: CaptureFixture[str], runner: str):
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_filter_multiple_patterns(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_filter_multiple_patterns(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     write_doctest(tmpdir, 'test.rst')
     write_doctest(tmpdir, 'test.txt')
     write_config(tmpdir, runner,
@@ -271,7 +271,7 @@ def test_filter_multiple_patterns(tmpdir: local, capsys: CaptureFixture[str], ru
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_skips(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_skips(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     root = clone_functional_sample('skips', tmpdir)
     write_config(root, runner,
                  parsers="[PythonCodeBlockParser(), SkipParser(), DocTestParser()]",
@@ -293,7 +293,7 @@ def clone_and_run_modules_tests(tmpdir: local, capsys: CaptureFixture[str], runn
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_modules(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_modules(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     sys.path.append((tmpdir / 'modules').strpath)
     results = clone_and_run_modules_tests(tmpdir, capsys, runner)
     assert results.total == 5, results.out.text
@@ -301,7 +301,7 @@ def test_modules(tmpdir: local, capsys: CaptureFixture[str], runner: str):
     assert results.errors == 0, results.out.text
 
 
-def test_modules_not_importable_pytest(tmpdir: local, capsys: CaptureFixture[str]):
+def test_modules_not_importable_pytest(tmpdir: local, capsys: CaptureFixture[str]) -> None:
     # NB: no append to sys.path
     results = clone_and_run_modules_tests(tmpdir, capsys, PYTEST)
     assert results.total == 5, results.out.text
@@ -316,7 +316,7 @@ def test_modules_not_importable_pytest(tmpdir: local, capsys: CaptureFixture[str
     out.then_find("ModuleNotFoundError: No module named 'b'")
 
 
-def test_modules_not_importable_unittest(tmpdir: local, capsys: CaptureFixture[str]):
+def test_modules_not_importable_unittest(tmpdir: local, capsys: CaptureFixture[str]) -> None:
     # NB: no append to sys.path
     results = clone_and_run_modules_tests(tmpdir, capsys, UNITTEST)
     assert results.total == 5, results.out.text
@@ -335,7 +335,7 @@ def test_modules_not_importable_unittest(tmpdir: local, capsys: CaptureFixture[s
 
 @skip_if_37_or_older()
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_package_and_docs(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_package_and_docs(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     root = clone_functional_sample('package_and_docs', tmpdir)
     write_config(root, runner,
                  patterns="['**/*.py', '**/*.rst']")
@@ -352,7 +352,7 @@ def test_package_and_docs(tmpdir: local, capsys: CaptureFixture[str], runner: st
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_multiple_sybils_process_all(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_multiple_sybils_process_all(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     write_doctest(tmpdir, 'test.rst')
     write_doctest(tmpdir, 'test.txt')
     config_template = """
@@ -375,7 +375,7 @@ def test_multiple_sybils_process_all(tmpdir: local, capsys: CaptureFixture[str],
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_multiple_sybils_process_one_each(tmpdir: local, capsys: CaptureFixture[str], runner: str):
+def test_multiple_sybils_process_one_each(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     write_doctest(tmpdir, 'test.rst')
     write_doctest(tmpdir, 'test.txt')
     config_template = """
@@ -393,7 +393,7 @@ def test_multiple_sybils_process_one_each(tmpdir: local, capsys: CaptureFixture[
 
 
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
-def test_myst(capsys: CaptureFixture[str], runner: str):
+def test_myst(capsys: CaptureFixture[str], runner: str) -> None:
     results = run(capsys, runner, functional_sample('myst'))
     out = results.out
 
@@ -433,6 +433,6 @@ def test_myst(capsys: CaptureFixture[str], runner: str):
         out.then_find("Exception: boom!")
 
 @skip_if_37_or_older()
-def test_codeblock_with_protocol_then_doctest():
+def test_codeblock_with_protocol_then_doctest() -> None:
     sybil = Sybil([PythonCodeBlockParser(), DocTestParser()])
     check_path(sample_path('protocol-typing.rst'), sybil, expected=3)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,21 +8,21 @@ from sybil.python import import_cleanup
 from .helpers import Finder, ast_docstrings
 
 
-def test_finder_present_but_is_not_present():
+def test_finder_present_but_is_not_present() -> None:
     finder = Finder('foo\nbaz\n')
     with pytest.raises(AssertionError) as info:
         finder.assert_present('bob')
     assert str(info.value) == "foo\nbaz\n\n'foo\\nbaz\\n'"
 
 
-def test_finder_not_present_but_is_present():
+def test_finder_not_present_but_is_present() -> None:
     finder = Finder('foo baz bar')
     with pytest.raises(AssertionError) as info:
         finder.assert_not_present('baz')
     assert str(info.value) == '\nfoo baz bar'
 
 
-def test_import_cleanup(tmpdir: local):
+def test_import_cleanup(tmpdir: local) -> None:
     (tmpdir / 'some_module.py').write('import unittest\nfoo = 1')
     (tmpdir / 'other_module.py').write('import other_module\nfoo = 1')
 
@@ -38,12 +38,12 @@ def test_import_cleanup(tmpdir: local):
     assert sys.path == initial_path
 
 
-def test_all_python_files(all_python_files):
+def test_all_python_files(all_python_files) -> None:
     count = len(all_python_files)
     assert count > 50, count
 
 
-def test_ast_docstrings(all_python_files):
+def test_ast_docstrings(all_python_files) -> None:
     seen_docstrings = 0
     for _, source in all_python_files:
         seen_docstrings += len(tuple(ast_docstrings(source)))

--- a/tests/test_lexing.py
+++ b/tests/test_lexing.py
@@ -7,14 +7,14 @@ from sybil.parsers.abstract.lexers import BlockLexer, LexingException
 from .helpers import lex, sample_path
 
 
-def test_examples_from_parsing_tests():
+def test_examples_from_parsing_tests() -> None:
     lexer = BlockLexer(start_pattern=re.compile('START'), end_pattern_template='END')
     path = sample_path('lexing-fail.txt')
     with ShouldRaise(LexingException(f"Could not match 'END' in {path}:\n'\\nEDN\\n'")):
         lex('lexing-fail.txt', lexer)
 
 
-def test_repr():
+def test_repr() -> None:
     compare(
         str(LexedRegion(36, 56, {'language': 'python', 'foo': None, 'source': 'X'*1000})),
         expected="<LexedRegion start=36 end=56 "

--- a/tests/test_myst_clear.py
+++ b/tests/test_myst_clear.py
@@ -2,7 +2,7 @@ from sybil.parsers.myst import ClearNamespaceParser, PythonCodeBlockParser
 from .helpers import parse
 
 
-def test_basic():
+def test_basic() -> None:
     examples, namespace = parse(
         'myst-clear.md', PythonCodeBlockParser(), ClearNamespaceParser(), expected=4
     )

--- a/tests/test_myst_codeblock.py
+++ b/tests/test_myst_codeblock.py
@@ -9,7 +9,7 @@ from sybil.parsers.myst import PythonCodeBlockParser, CodeBlockParser
 from .helpers import check_excinfo, parse
 
 
-def test_basic():
+def test_basic() -> None:
     examples, namespace = parse('myst-codeblock.md', PythonCodeBlockParser(), expected=7)
     namespace['y'] = namespace['z'] = 0
     assert examples[0].evaluate() is None
@@ -35,7 +35,7 @@ def test_basic():
     assert '__builtins__' not in namespace
 
 
-def test_doctest_at_end_of_fenced_codeblock():
+def test_doctest_at_end_of_fenced_codeblock() -> None:
     examples, namespace = parse('myst-codeblock-doctests-end-of-fenced-codeblocks.md',
                                 PythonCodeBlockParser(), expected=2)
     assert examples[0].evaluate() is None
@@ -43,7 +43,7 @@ def test_doctest_at_end_of_fenced_codeblock():
     assert namespace['b'] == 2
 
 
-def test_other_language_composition_pass():
+def test_other_language_composition_pass() -> None:
 
     def oh_hai(example):
         assert isinstance(example, Example)
@@ -55,7 +55,7 @@ def test_other_language_composition_pass():
 
 
 
-def test_other_language_composition_fail():
+def test_other_language_composition_fail() -> None:
     def oh_noez(example):
         if 'KTHXBYE' in example.parsed:
             raise ValueError('oh noez')
@@ -66,7 +66,7 @@ def test_other_language_composition_fail():
         examples[0].evaluate()
 
 
-def test_other_language_no_evaluator():
+def test_other_language_no_evaluator() -> None:
     parser = CodeBlockParser('foo')
     with pytest.raises(NotImplementedError):
         parser.evaluate(...)
@@ -81,7 +81,7 @@ class LolCodeCodeBlockParser(CodeBlockParser):
             raise ValueError(repr(example.parsed))
 
 
-def test_other_language_inheritance():
+def test_other_language_inheritance() -> None:
     examples, namespace = parse('myst-codeblock-lolcode.md', LolCodeCodeBlockParser(), expected=2)
     examples[0].evaluate()
     with pytest.raises(ValueError) as excinfo:
@@ -106,20 +106,20 @@ def future_import_checks(*future_imports):
     return namespace['foo']
 
 
-def test_no_future_imports():
+def test_no_future_imports() -> None:
     future_import_checks()
 
 
-def test_single_future_import():
+def test_single_future_import() -> None:
     future_import_checks('barry_as_FLUFL')
 
 
-def test_multiple_future_imports():
+def test_multiple_future_imports() -> None:
     future_import_checks('barry_as_FLUFL', 'print_function')
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
-def test_functional_future_imports():
+def test_functional_future_imports() -> None:
     foo = future_import_checks('annotations')
     # This will keep working but not be an effective test once PEP 563 finally lands:
     assert foo.__code__.co_flags & __future__.annotations.compiler_flag

--- a/tests/test_myst_doctest.py
+++ b/tests/test_myst_doctest.py
@@ -10,7 +10,7 @@ from sybil.parsers.myst import DocTestDirectiveParser, PythonCodeBlockParser
 from tests.helpers import parse, sample_path
 
 
-def test_use_existing_doctest_parser():
+def test_use_existing_doctest_parser() -> None:
     path = sample_path('myst-doctest-use-rest.md')
     examples, namespace = parse('myst-doctest-use-rest.md', ReSTDocTestParser(), expected=6)
     examples[0].evaluate()
@@ -32,7 +32,7 @@ def test_use_existing_doctest_parser():
     examples[5].evaluate()
 
 
-def test_use_python_codeblock_parser():
+def test_use_python_codeblock_parser() -> None:
     examples, namespace = parse('myst-doctest.md', PythonCodeBlockParser(), expected=3)
     examples[0].evaluate()
     examples[1].evaluate()
@@ -41,7 +41,7 @@ def test_use_python_codeblock_parser():
     assert namespace['x'] == 3
 
 
-def test_fail_with_options_using_python_codeblock_parser():
+def test_fail_with_options_using_python_codeblock_parser() -> None:
     parser = PythonCodeBlockParser(doctest_optionflags=REPORT_NDIFF|ELLIPSIS)
     examples, namespace = parse('myst-doctest-fail.md', parser, expected=1)
     with pytest.raises(SybilFailure) as excinfo:
@@ -53,7 +53,7 @@ def test_fail_with_options_using_python_codeblock_parser():
     )
 
 
-def test_use_doctest_role_parser():
+def test_use_doctest_role_parser() -> None:
     path = sample_path('myst-doctest.md')
     examples, namespace = parse('myst-doctest.md', DocTestDirectiveParser(), expected=4)
     examples[0].evaluate()
@@ -71,7 +71,7 @@ def test_use_doctest_role_parser():
     ))
 
 
-def test_fail_with_options_using_doctest_role_parser():
+def test_fail_with_options_using_doctest_role_parser() -> None:
     parser = DocTestDirectiveParser(optionflags=REPORT_NDIFF|ELLIPSIS)
     examples, namespace = parse('myst-doctest-fail.md', parser, expected=1)
     with pytest.raises(SybilFailure) as excinfo:

--- a/tests/test_myst_lexers.py
+++ b/tests/test_myst_lexers.py
@@ -8,7 +8,7 @@ from sybil.region import LexedRegion
 from .helpers import lex
 
 
-def test_fenced_code_block():
+def test_fenced_code_block() -> None:
     lexer = FencedCodeBlockLexer('py?thon')
     compare(lex('myst-lexers.md', lexer), expected=[
         LexedRegion(36, 56, {'language': 'python', 'source': '>>> 1+1\n2\n'}),
@@ -16,14 +16,14 @@ def test_fenced_code_block():
     ])
 
 
-def test_fenced_code_block_with_mapping():
+def test_fenced_code_block_with_mapping() -> None:
     lexer = FencedCodeBlockLexer('python', mapping={'source': 'body'})
     compare(lex('myst-lexers.md', lexer), expected=[
         LexedRegion(36, 56, {'body': '>>> 1+1\n2\n'})
     ])
 
 
-def test_myst_directives():
+def test_myst_directives() -> None:
     lexer = DirectiveLexer(directive='[^}]+', arguments='.*')
     compare(lex('myst-lexers.md', lexer), expected=[
         LexedRegion(110, 145, {
@@ -45,7 +45,7 @@ def test_myst_directives():
     ])
 
 
-def test_examples_from_parsing_tests():
+def test_examples_from_parsing_tests() -> None:
     lexer = DirectiveLexer(directive='code-block', arguments='python')
     compare(lex('myst-codeblock.md', lexer), expected=[
         LexedRegion(99, 151, {
@@ -59,14 +59,14 @@ def test_examples_from_parsing_tests():
     ])
 
 
-def test_myst_directives_with_mapping():
+def test_myst_directives_with_mapping() -> None:
     lexer = DirectiveLexer(directive='directivename', arguments='.*', mapping={'arguments': 'foo'})
     compare(lex('myst-lexers.md', lexer), expected=[
         LexedRegion(188, 273, {'foo': 'arguments'}),
     ])
 
 
-def test_myst_percent_comment_invisible_directive():
+def test_myst_percent_comment_invisible_directive() -> None:
     lexer = DirectiveInPercentCommentLexer(
         directive='(invisible-)?code(-block)?', arguments='py.*'
     )
@@ -82,7 +82,7 @@ def test_myst_percent_comment_invisible_directive():
     ])
 
 
-def test_myst_percent_comment_invisible_directive_mapping():
+def test_myst_percent_comment_invisible_directive_mapping() -> None:
     lexer = DirectiveInPercentCommentLexer(
         directive='inv[^:]+', arguments='python', mapping={'arguments': 'language'}
     )
@@ -91,7 +91,7 @@ def test_myst_percent_comment_invisible_directive_mapping():
     ])
 
 
-def test_myst_html_comment_invisible_directive():
+def test_myst_html_comment_invisible_directive() -> None:
     lexer = DirectiveInHTMLCommentLexer(
         directive='(invisible-)?code(-block)?', arguments='py.*'
     )

--- a/tests/test_myst_skip.py
+++ b/tests/test_myst_skip.py
@@ -2,7 +2,7 @@ from sybil.parsers.myst import PythonCodeBlockParser, SkipParser
 from .helpers import parse
 
 
-def test_basic():
+def test_basic() -> None:
     examples, namespace = parse('myst-skip.md', PythonCodeBlockParser(), SkipParser(), expected=9)
     for example in examples:
         example.evaluate()

--- a/tests/test_rest_lexers.py
+++ b/tests/test_rest_lexers.py
@@ -6,7 +6,7 @@ from sybil.region import LexedRegion
 from .helpers import lex, lex_text
 
 
-def test_examples_from_parsing_tests():
+def test_examples_from_parsing_tests() -> None:
     lexer = DirectiveLexer(directive='code-block', arguments='python')
     compare(lex('codeblock.txt', lexer)[:2], expected=[
         LexedRegion(23, 56, {
@@ -20,7 +20,7 @@ def test_examples_from_parsing_tests():
     ])
 
 
-def test_examples_from_directive_tests():
+def test_examples_from_directive_tests() -> None:
     lexer = DirectiveLexer(directive='doctest')
     compare(lex('doctest_directive.txt', lexer), expected=[
         LexedRegion(102, 136, {
@@ -38,7 +38,7 @@ def test_examples_from_directive_tests():
     ])
 
 
-def test_directive_nested_in_md():
+def test_directive_nested_in_md() -> None:
     lexer = DirectiveLexer(directive='doctest')
     compare(lex('doctest_rest_nested_in_md.md', lexer), expected=[
         LexedRegion(14, 47, {
@@ -48,7 +48,7 @@ def test_directive_nested_in_md():
     ])
 
 
-def test_directive_with_single_line_body_at_end_of_string():
+def test_directive_with_single_line_body_at_end_of_string() -> None:
     text = """
         My comment
     
@@ -70,7 +70,7 @@ def test_directive_with_single_line_body_at_end_of_string():
     ))
 
 
-def test_directive_with_multi_line_body_at_end_of_string():
+def test_directive_with_multi_line_body_at_end_of_string() -> None:
     text = """
         My comment
 

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -7,14 +7,14 @@ from sybil.parsers.rest import PythonCodeBlockParser, DocTestParser, SkipParser
 from .helpers import parse
 
 
-def test_basic():
+def test_basic() -> None:
     examples, namespace = parse('skip.txt', PythonCodeBlockParser(), SkipParser(), expected=9)
     for example in examples:
         example.evaluate()
     assert namespace['run'] == [2, 5]
 
 
-def test_conditional_edge_cases():
+def test_conditional_edge_cases() -> None:
     examples, namespace = parse(
         'skip-conditional-edges.txt',
         DocTestParser(), PythonCodeBlockParser(), SkipParser(),
@@ -33,7 +33,7 @@ def test_conditional_edge_cases():
     assert skipped == ['only true on python 2']
 
 
-def test_conditional_full():
+def test_conditional_full() -> None:
     examples, namespace = parse('skip-conditional.txt', DocTestParser(), SkipParser(), expected=9)
     namespace['result'] = result = []
     for example in examples:
@@ -51,7 +51,7 @@ def test_conditional_full():
     ]
 
 
-def test_bad():
+def test_bad() -> None:
     examples, namespace = parse('skip-conditional-bad.txt', SkipParser(), expected=3)
 
     with pytest.raises(ValueError) as excinfo:

--- a/tests/test_sybil.py
+++ b/tests/test_sybil.py
@@ -22,20 +22,20 @@ def document():
 
 class TestRegion:
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         region = Region(0, 1, 'parsed', 'evaluator')
         assert repr(region) == "<Region start=0 end=1 'evaluator'>"
 
 
 class TestExample:
 
-    def test_repr(self, document):
+    def test_repr(self, document) -> None:
         region = Region(0, 1, 'parsed', 'evaluator')
         example = Example(document, 1, 2, region, {})
         assert (repr(example) ==
                 "<Example path=/the/path line=1 column=2 using 'evaluator'>")
 
-    def test_evaluate_okay(self, document):
+    def test_evaluate_okay(self, document) -> None:
         def evaluator(example):
             example.namespace['parsed'] = example.parsed
         region = Region(0, 1, 'the data', evaluator)
@@ -45,7 +45,7 @@ class TestExample:
         assert result is None
         assert namespace == {'parsed': 'the data'}
 
-    def test_evaluate_not_okay(self, document):
+    def test_evaluate_not_okay(self, document) -> None:
         def evaluator(example):
             return 'foo!'
         region = Region(0, 1, 'the data', evaluator)
@@ -59,7 +59,7 @@ class TestExample:
         assert excinfo.value.example is example
         assert excinfo.value.result == 'foo!'
 
-    def test_evaluate_raises_exception(self, document):
+    def test_evaluate_raises_exception(self, document) -> None:
         def evaluator(example):
             raise ValueError('foo!')
         region = Region(0, 1, 'the data', evaluator)
@@ -71,26 +71,26 @@ class TestExample:
 
 class TestDocument:
 
-    def test_add(self, document):
+    def test_add(self, document) -> None:
         region = Region(0, 1, None, None)
         document.add(region)
         assert [e.region for e in document] == [region]
 
-    def test_add_no_overlap(self, document):
+    def test_add_no_overlap(self, document) -> None:
         region1 = Region(0, 1, None, None)
         region2 = Region(6, 8, None, None)
         document.add(region1)
         document.add(region2)
         assert [e.region for e in document] == [region1, region2]
 
-    def test_add_out_of_order(self, document):
+    def test_add_out_of_order(self, document) -> None:
         region1 = Region(0, 1, None, None)
         region2 = Region(6, 8, None, None)
         document.add(region2)
         document.add(region1)
         assert [e.region for e in document] == [region1, region2]
 
-    def test_add_adjacent(self, document):
+    def test_add_adjacent(self, document) -> None:
         region1 = Region(0, 1, None, None)
         region2 = Region(1, 2, None, None)
         region3 = Region(2, 3, None, None)
@@ -99,7 +99,7 @@ class TestDocument:
         document.add(region2)
         assert [e.region for e in document] == [region1, region2, region3]
 
-    def test_add_before_start(self, document):
+    def test_add_before_start(self, document) -> None:
         region = Region(-1, 0, None, None)
         with pytest.raises(ValueError) as excinfo:
             document.add(region)
@@ -109,7 +109,7 @@ class TestDocument:
             'is before start of document'
         )
 
-    def test_add_after_end(self, document):
+    def test_add_after_end(self, document) -> None:
         region = Region(len(document.text), len(document.text)+1, None, None)
         with pytest.raises(ValueError) as excinfo:
             document.add(region)
@@ -119,7 +119,7 @@ class TestDocument:
             'goes beyond end of document'
         )
 
-    def test_add_overlaps_with_previous(self, document):
+    def test_add_overlaps_with_previous(self, document) -> None:
         region1 = Region(0, 2, None, None)
         region2 = Region(1, 3, None, None)
         document.add(region1)
@@ -132,7 +132,7 @@ class TestDocument:
             ' from line 1, column 2 to line 1, column 4'
         )
 
-    def test_add_at_same_place(self, document):
+    def test_add_at_same_place(self, document) -> None:
         region1 = Region(0, 2, None, None)
         region2 = Region(0, 3, None, None)
         document.add(region1)
@@ -145,7 +145,7 @@ class TestDocument:
             ' from line 1, column 1 to line 1, column 3'
         )
 
-    def test_add_identical(self, document):
+    def test_add_identical(self, document) -> None:
         region1 = Region(0, 2, None, None)
         region2 = Region(0, 2, None, None)
         document.add(region1)
@@ -158,7 +158,7 @@ class TestDocument:
             ' from line 1, column 1 to line 1, column 3'
         )
 
-    def test_add_overlaps_with_next(self, document):
+    def test_add_overlaps_with_next(self, document) -> None:
         region1 = Region(0, 1, None, None)
         region2 = Region(1, 3, None, None)
         region3 = Region(2, 4, None, None)
@@ -173,11 +173,11 @@ class TestDocument:
             'from line 1, column 3 to line 1, column 5'
         )
 
-    def test_example_path(self, document):
+    def test_example_path(self, document) -> None:
         document.add(Region(0, 1, None, None))
         assert [e.document for e in document] == [document]
 
-    def test_example_line_and_column(self):
+    def test_example_line_and_column(self) -> None:
         text = 'R1XYZ\nR2XYZ\nR3XYZ\nR4XYZ\nR4XYZ\n'
         i = text.index
         document = Document(text, '')
@@ -222,7 +222,7 @@ def evaluate_examples(examples):
 
 class TestSybil:
 
-    def test_parse(self):
+    def test_parse(self) -> None:
         sybil = Sybil([parse_for_x, parse_for_y])
         document = sybil.parse(Path(sample_path('sample1.txt')))
         assert (evaluate_examples(document) ==
@@ -233,7 +233,7 @@ class TestSybil:
                 ['X count was 3 instead of 4',
                  'Y count was 3, as expected'])
 
-    def test_explicit_encoding(self, tmp_path: Path):
+    def test_explicit_encoding(self, tmp_path: Path) -> None:
         path = (tmp_path / 'encoded.txt')
         path.write_text(u'X 1 check\n\xa3', encoding='charmap')
         sybil = Sybil([parse_for_x], encoding='charmap')
@@ -241,7 +241,7 @@ class TestSybil:
         assert (evaluate_examples(document) ==
                 ['X count was 1, as expected'])
 
-    def test_augment_document_mapping(self, tmpdir: local):
+    def test_augment_document_mapping(self, tmpdir: local) -> None:
 
         class TextDocument(Document):
             pass
@@ -252,7 +252,7 @@ class TestSybil:
         document = sybil.parse(write_doctest(tmpdir, 'test.rst'))
         assert type(document) is Document
 
-    def test_override_document_mapping(self):
+    def test_override_document_mapping(self) -> None:
         sybil = Sybil([parse_for_x, parse_for_y], document_types={'.py': PythonDocument})
         document = sybil.parse(Path(sample_path('sample1.txt')))
         assert (evaluate_examples(document) ==
@@ -263,7 +263,7 @@ class TestSybil:
                 ['X count was 4, as expected',
                  'Y count was 3, as expected'])
 
-    def test_addition(self):
+    def test_addition(self) -> None:
         rest = Sybil([parse_for_x])
         myst = Sybil([parse_for_y])
         sybil = rest + myst
@@ -272,7 +272,7 @@ class TestSybil:
         assert sybil.pytest
         assert sybil.unittest
 
-    def test_addition_to_collection(self):
+    def test_addition_to_collection(self) -> None:
         rest = Sybil([parse_for_x])
         myst = Sybil([parse_for_y])
         bust = Sybil([parse_for_y])
@@ -297,7 +297,7 @@ def parse(document):
         yield Region(m.start(), m.end(), m.start(), check_into_namespace)
 
 
-def test_namespace(capsys):
+def test_namespace(capsys) -> None:
     sybil = Sybil([parse], path='./samples')
     documents = [sybil.parse(p) for p in sorted(sybil.path.glob('sample*.txt'))]
     actual = []


### PR DESCRIPTION
This is one step towards adding mypy and shipping type hints. This change fixes all errors of the format:

```
tests/test_codeblock.py:136: error: Function is missing a return type annotation  [no-untyped-def]
tests/test_codeblock.py:136: note: Use "-> None" if function does not return a value
```

when running:

```
mypy --strict sybil tests
```