### PR TITLE
Fix some "attr-defined" mypy errors: Explicitly re-export relied on a…

### DIFF
--- a/sybil/__init__.py
+++ b/sybil/__init__.py
@@ -2,3 +2,12 @@ from .sybil import Sybil
 from .document import Document
 from .region import Region, LexedRegion, Lexeme
 from .example import Example
+
+__all__ = [
+    'Sybil',
+    'Document',
+    'Region',
+    'LexedRegion',
+    'Lexeme',
+    'Example',
+]

--- a/sybil/parsers/abstract/__init__.py
+++ b/sybil/parsers/abstract/__init__.py
@@ -2,3 +2,10 @@ from .clear import AbstractClearNamespaceParser
 from .codeblock import AbstractCodeBlockParser
 from .skip import AbstractSkipParser
 from .doctest import DocTestStringParser
+
+__all__ = [
+    'AbstractClearNamespaceParser',
+    'AbstractCodeBlockParser',
+    'AbstractSkipParser',
+    'DocTestStringParser',
+]

--- a/sybil/parsers/codeblock.py
+++ b/sybil/parsers/codeblock.py
@@ -1,3 +1,5 @@
 # THIS MODULE IS FOR BACKWARDS COMPATIBILITY ONLY!
 
 from .rest import CodeBlockParser, PythonCodeBlockParser
+
+__all__ = ['CodeBlockParser', 'PythonCodeBlockParser']

--- a/sybil/parsers/doctest.py
+++ b/sybil/parsers/doctest.py
@@ -1,2 +1,4 @@
 # THIS MODULE IS FOR BACKWARDS COMPATIBILITY ONLY!
 from .rest import DocTestParser
+
+__all__ = ['DocTestParser']

--- a/sybil/parsers/myst/__init__.py
+++ b/sybil/parsers/myst/__init__.py
@@ -2,3 +2,11 @@ from .codeblock import CodeBlockParser, PythonCodeBlockParser
 from .doctest import DocTestDirectiveParser
 from .skip import SkipParser
 from .clear import ClearNamespaceParser
+
+__all__ = [
+    'CodeBlockParser',
+    'PythonCodeBlockParser',
+    'DocTestDirectiveParser',
+    'SkipParser',
+    'ClearNamespaceParser',
+]

--- a/sybil/parsers/rest/__init__.py
+++ b/sybil/parsers/rest/__init__.py
@@ -3,3 +3,13 @@ from .codeblock import CodeBlockParser, PythonCodeBlockParser
 from .clear import ClearNamespaceParser
 from .doctest import DocTestParser, DocTestDirectiveParser
 from .skip import SkipParser
+
+__all__ = [
+    'CaptureParser',
+    'CodeBlockParser',
+    'PythonCodeBlockParser',
+    'ClearNamespaceParser',
+    'DocTestParser',
+    'DocTestDirectiveParser',
+    'SkipParser',
+]


### PR DESCRIPTION
…ttributes

This removes errors in the format:

```
tests/test_codeblock.py:10: error: Module "sybil.parsers.codeblock" does not explicitly export attribute "CodeBlockParser"  [attr-defined]
```

when running:

```
mypy --strict sybil tests
```