### PR TITLE
Add type hints for a number of test helper functions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -34,11 +34,11 @@ def _find_python_files() -> List[Tuple[Path, str]]:
 
 
 @pytest.fixture
-def all_python_files():
+def all_python_files() -> List[Tuple[Path, str]]:
     return _find_python_files()
 
 
-def pytest_generate_tests(metafunc):
+def pytest_generate_tests(metafunc) -> None:
     files = _find_python_files()
     ids = [str(f[0]) for f in files]
     if "python_file" in metafunc.fixturenames:

--- a/tests/functional/pytest/conftest.py
+++ b/tests/functional/pytest/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from functools import partial
 import re
+from typing import Generator
 
 import pytest
 
@@ -9,34 +10,34 @@ from sybil.parsers.rest import PythonCodeBlockParser
 
 
 @pytest.fixture(scope="function")
-def function_fixture():
+def function_fixture() -> Generator[str, None, None]:
     print('function_fixture setup')
     yield 'f'
     print(' function_fixture teardown')
 
 
 @pytest.fixture(scope="class")
-def class_fixture():
+def class_fixture() -> Generator[str, None, None]:
     print('class_fixture setup')
     yield 'c'
     print('class_fixture teardown')
 
 
 @pytest.fixture(scope="module")
-def module_fixture():
+def module_fixture() -> Generator[str, None, None]:
     print('module_fixture setup')
     yield 'm'
     print('module_fixture teardown')
 
 
 @pytest.fixture(scope="session")
-def session_fixture():
+def session_fixture() -> Generator[str, None, None]:
     print('session_fixture setup')
     yield 's'
     print('session_fixture teardown')
 
 
-def check(letter, example):
+def check(letter, example) -> str:
     namespace = example.namespace
     for name in (
         'x', 'session_fixture', 'module_fixture',
@@ -63,12 +64,12 @@ def parse_for(letter, document):
                      partial(check, letter))
 
 
-def sybil_setup(namespace):
+def sybil_setup(namespace) -> None:
     print('sybil setup', end=' ')
     namespace['x'] = 0
 
 
-def sybil_teardown(namespace):
+def sybil_teardown(namespace) -> None:
     print('sybil teardown', namespace['x'])
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -109,19 +109,19 @@ class Finder:
         self.text = text
         self.index = 0
 
-    def then_find(self, substring):
+    def then_find(self, substring: str) -> None:
         assert substring in self.text[self.index:], self.text[self.index:]
         self.index = self.text.index(substring, self.index)
 
-    def assert_present(self, text):
+    def assert_present(self, text: str) -> None:
         assert text in self.text, f'{self.text}\n{self.text!r}'
 
-    def assert_not_present(self, text):
+    def assert_not_present(self, text: str) -> None:
         index = self.text.find(text)
         if index > -1:
             raise AssertionError('\n'+self.text[index-500:index+500])
 
-    def assert_has_run(self, integration: str, file: str, *, line: int = 1, column: int = 1):
+    def assert_has_run(self, integration: str, file: str, *, line: int = 1, column: int = 1) -> None:
         self.assert_present(TEST_OUTPUT_TEMPLATES[integration].format(
             file=file, line=line, column=column
         ))

--- a/tests/samples/docstrings.py
+++ b/tests/samples/docstrings.py
@@ -4,7 +4,7 @@ def r_prefixed_docstring() -> None:
     """
 
 
-def function_with_codeblock_in_middle(text):
+def function_with_codeblock_in_middle(text: str) -> None:
     """
     My comment
 
@@ -16,7 +16,7 @@ def function_with_codeblock_in_middle(text):
     assert text == 'Hello World'
 
 
-def function_with_single_line_codeblock_at_end(text):
+def function_with_single_line_codeblock_at_end(text: str) -> None:
     """
     My comment
 

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -148,7 +148,7 @@ def test_sybil_example_count(all_python_files) -> None:
     assert seen_examples_from_docstrings == seen_examples_from_source
 
 
-def check_sybil_against_doctest(path, text):
+def check_sybil_against_doctest(path: Path, text: str) -> None:
     skip_if_37_or_older()
     problems = []
     name = str(path)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Generator
 
 import pytest
 from py.path import local
@@ -14,7 +15,7 @@ from .helpers import (
 
 
 @pytest.fixture(autouse=True)
-def cleanup_imports():
+def cleanup_imports() -> Generator[None, None, None]:
     with import_cleanup():
         yield
 

--- a/tests/test_myst_codeblock.py
+++ b/tests/test_myst_codeblock.py
@@ -45,7 +45,7 @@ def test_doctest_at_end_of_fenced_codeblock() -> None:
 
 def test_other_language_composition_pass() -> None:
 
-    def oh_hai(example):
+    def oh_hai(example: Example) -> None:
         assert isinstance(example, Example)
         assert 'HAI' in example.parsed
 
@@ -56,7 +56,7 @@ def test_other_language_composition_pass() -> None:
 
 
 def test_other_language_composition_fail() -> None:
-    def oh_noez(example):
+    def oh_noez(example: Example) -> None:
         if 'KTHXBYE' in example.parsed:
             raise ValueError('oh noez')
 
@@ -76,7 +76,7 @@ class LolCodeCodeBlockParser(CodeBlockParser):
 
     language = 'lolcode'
 
-    def evaluate(self, example: Example):
+    def evaluate(self, example: Example) -> None:
         if example.parsed != 'HAI\n':
             raise ValueError(repr(example.parsed))
 

--- a/tests/test_sybil.py
+++ b/tests/test_sybil.py
@@ -16,7 +16,7 @@ from .helpers import sample_path, write_doctest
 
 
 @pytest.fixture()
-def document():
+def document() -> Document:
     return Document('ABCDEFGH', '/the/path')
 
 


### PR DESCRIPTION
This adds type hints for all `pytest` fixtures in
`sybil/` and `tests/`, as well as some other test helper functions.

Some people prefer to use `Iterator` over `Generator` for typing `pytest` fixtures, but this can cause issues, e.g. https://youtrack.jetbrains.com/issue/PY-40318/pytest-fixtures-with-yield-return-types-defined-as-Iterator and Generator is an "accepted answer" on `pytest-dev`: https://github.com/pytest-dev/pytest/discussions/7809#discussioncomment-87250. I don't fully understand that, but I went with the accepted answer.