### PR TITLE
Add type hints to sybil.integration.unittest

### DIFF
--- a/sybil/document.py
+++ b/sybil/document.py
@@ -4,7 +4,7 @@ from ast import AsyncFunctionDef, FunctionDef, ClassDef, Module, Expr, Constant
 from bisect import bisect
 from io import open
 from pathlib import Path
-from typing import List, Iterable, Pattern, Tuple, Match, Optional, Sequence
+from typing import List, Iterator, Pattern, Tuple, Match, Optional, Sequence
 
 from .example import Example
 from .python import import_path
@@ -101,7 +101,7 @@ class Document:
                 self.raise_overlap(region, next)
         self.regions.insert(index, entry)
 
-    def __iter__(self) -> Iterable[Example]:
+    def __iter__(self) -> Iterator[Example]:
         line = 1
         place = 0
         for _, region in self.regions:

--- a/sybil/integration/unittest.py
+++ b/sybil/integration/unittest.py
@@ -1,22 +1,28 @@
-from typing import TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Optional
 from unittest import TestCase as BaseTestCase, TestSuite
 
 if TYPE_CHECKING:
+    from unittest.loader import TestLoader
+
     from ..sybil import Sybil
+    from sybil.example import Example
 
 
 class TestCase(BaseTestCase):
 
-    sybil = namespace = None
+    sybil: Sybil
+    namespace: dict[str, Any]
 
-    def __init__(self, example) -> None:
+    def __init__(self, example: Example) -> None:
         BaseTestCase.__init__(self)
         self.example = example
 
     def runTest(self) -> None:
         self.example.evaluate()
 
-    def id(self):
+    def id(self) -> str:
         return '{},line:{},column:{}'.format(
             self.example.path, self.example.line, self.example.column
         )
@@ -34,9 +40,15 @@ class TestCase(BaseTestCase):
             cls.sybil.teardown(cls.namespace)
 
 
-def unittest_integration(*sybils: 'Sybil'):
+def unittest_integration(
+    *sybils: 'Sybil',
+) -> Callable[[Optional[TestLoader], Optional[TestSuite], Optional[str]], TestSuite]:
 
-    def load_tests(loader=None, tests=None, pattern=None):
+    def load_tests(
+        loader: Optional[TestLoader] = None,
+        tests: Optional[TestSuite] = None,
+        pattern: Optional[str] = None,
+    ) -> TestSuite:
         suite = TestSuite()
         for sybil in sybils:
             for path in sorted(sybil.path.glob('**/*')):

--- a/sybil/integration/unittest.py
+++ b/sybil/integration/unittest.py
@@ -1,21 +1,19 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 from unittest import TestCase as BaseTestCase, TestSuite
+from unittest.loader import TestLoader
+
+from sybil.example import Example
 
 if TYPE_CHECKING:
-    from unittest.loader import TestLoader
-
     from ..sybil import Sybil
-    from sybil.example import Example
 
 
 class TestCase(BaseTestCase):
 
-    sybil: Sybil
-    namespace: dict[str, Any]
+    sybil: 'Sybil'
+    namespace: Dict[str, Any]
 
-    def __init__(self, example: Example) -> None:
+    def __init__(self, example: 'Example') -> None:
         BaseTestCase.__init__(self)
         self.example = example
 


### PR DESCRIPTION
This resolves all type errors when running `mypy --strict sybil/integration/unittest.py`.