### PR TITLE
Define pytest skipif as variable not function

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -253,6 +253,8 @@ def ast_docstrings(python_source_code: str) -> Sequence[str]:
                 yield docstring
 
 
-def skip_if_37_or_older():
-    return pytest.mark.skipif(sys.version_info[:2] < (3, 8), reason="requires python3.8 or higher")
+skip_if_37_or_older = pytest.mark.skipif(
+    sys.version_info[:2] < (3, 8),
+    reason="requires python3.8 or higher",
+)
 

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -131,7 +131,7 @@ UNPARSEABLE = {
 MINIMUM_EXPECTED_DOCTESTS = 9
 
 
-@skip_if_37_or_older()
+@skip_if_37_or_older
 def test_sybil_example_count(all_python_files) -> None:
     parser = DocTestStringParser()
 
@@ -149,7 +149,7 @@ def test_sybil_example_count(all_python_files) -> None:
 
 
 def check_sybil_against_doctest(path, text):
-    skip_if_37_or_older()
+    skip_if_37_or_older
     problems = []
     name = str(path)
     regions = list(DocTestStringParser()(text, path))
@@ -177,7 +177,7 @@ def test_all_docstest_examples_extracted_from_source_correctly(python_file) -> N
     check_sybil_against_doctest(path, source)
 
 
-@skip_if_37_or_older()
+@skip_if_37_or_older
 def test_all_docstest_examples_extracted_from_docstrings_correctly(python_file) -> None:
     path, source = python_file
     for start, end, docstring in PythonDocStringDocument.extract_docstrings(source):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -10,7 +10,7 @@ from sybil.document import PythonDocStringDocument
 from .helpers import ast_docstrings, skip_if_37_or_older
 
 
-@skip_if_37_or_older()
+@skip_if_37_or_older
 def test_extract_docstring() -> None:
     """
     This is a function docstring.
@@ -22,7 +22,7 @@ def test_extract_docstring() -> None:
     compare(expected, actual=[python_source_code[s:e] for s, e, _ in actual], show_whitespace=True)
 
 
-@skip_if_37_or_older()
+@skip_if_37_or_older
 def test_all_docstrings_extracted_correctly(python_file) -> None:
     problems = []
     path, source = python_file

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -333,7 +333,7 @@ def test_modules_not_importable_unittest(tmpdir: local, capsys: CaptureFixture[s
     out.then_find("ModuleNotFoundError: No module named 'b'")
 
 
-@skip_if_37_or_older()
+@skip_if_37_or_older
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
 def test_package_and_docs(tmpdir: local, capsys: CaptureFixture[str], runner: str) -> None:
     root = clone_functional_sample('package_and_docs', tmpdir)
@@ -432,7 +432,7 @@ def test_myst(capsys: CaptureFixture[str], runner: str) -> None:
     if runner == PYTEST:
         out.then_find("Exception: boom!")
 
-@skip_if_37_or_older()
+@skip_if_37_or_older
 def test_codeblock_with_protocol_then_doctest() -> None:
     sybil = Sybil([PythonCodeBlockParser(), DocTestParser()])
     check_path(sample_path('protocol-typing.rst'), sybil, expected=3)


### PR DESCRIPTION
This resolves mypy errors in the format:

```
tests/test_document.py:13: error: Call to untyped function "skip_if_37_or_older" in typed context  [no-untyped-call]
```

We could instead add a type to the existing function but:

* `pytest` does not ship a public type for this, so this change would rely on importing a private type
* This change matches the documented way of sharing skipif markers in the pytest documentation at https://docs.pytest.org/en/7.1.x/how-to/skipping.html#id1