### PR TITLE
Add type hints to sybil.region

### DIFF
--- a/sybil/region.py
+++ b/sybil/region.py
@@ -10,10 +10,10 @@ class Lexeme(str):
     that contains it.
     """
 
-    def __new__(cls, text: str, offset, line_offset: int):
+    def __new__(cls, text: str, offset: int, line_offset: int) -> 'Lexeme':
         return str.__new__(cls, text)
 
-    def __init__(self, text: str, offset, line_offset: int) -> None:
+    def __init__(self, text: str, offset: int, line_offset: int) -> None:
         self.text, self.offset, self.line_offset = text, offset, line_offset
 
 
@@ -77,12 +77,12 @@ class Region:
             self.start, self.end, self.evaluator
         )
 
-    def __lt__(self, other):
+    def __lt__(self, other: Any) -> bool:
         assert isinstance(other, type(self)), f"{type(other)} not supported for <"
         assert self.start == other.start  # This is where this may happen, if not something weird
         return True
 
-    def adjust(self, lexed: Union['Region', 'LexedRegion'], lexeme: Lexeme):
+    def adjust(self, lexed: Union['Region', 'LexedRegion'], lexeme: Lexeme) -> None:
         """
         Adjust the start and end of this region based on the provided :class:`Lexeme`
         and :class:`LexedRegion` or :class:`Region` that lexeme came from.

--- a/sybil/region.py
+++ b/sybil/region.py
@@ -77,7 +77,7 @@ class Region:
             self.start, self.end, self.evaluator
         )
 
-    def __lt__(self, other: Any) -> bool:
+    def __lt__(self, other: 'Region') -> bool:
         assert isinstance(other, type(self)), f"{type(other)} not supported for <"
         assert self.start == other.start  # This is where this may happen, if not something weird
         return True


### PR DESCRIPTION
This resolves all type errors when running `mypy --strict sybil/region.py`.