### PR TITLE
Add type hints to sybil/parsers/rest/codeblock.py

### DIFF
--- a/sybil/parsers/rest/codeblock.py
+++ b/sybil/parsers/rest/codeblock.py
@@ -2,7 +2,7 @@ from sybil.evaluators.python import pad, PythonEvaluator
 from sybil.parsers.abstract import AbstractCodeBlockParser
 from sybil.parsers.rest.lexers import DirectiveLexer, DirectiveInCommentLexer
 from sybil.typing import Evaluator
-from typing import Optional
+from typing import Optional, Sequence
 
 
 class CodeBlockParser(AbstractCodeBlockParser):
@@ -34,10 +34,10 @@ class PythonCodeBlockParser(CodeBlockParser):
     A :any:`Parser` for Python :ref:`codeblock-parser` examples.
 
     :param future_imports:
-        An optional list of strings that will be turned into
+        An optional sequence of strings that will be turned into
         ``from __future__ import ...`` statements and prepended to the code
         in each of the examples found by this parser.
     """
 
-    def __init__(self, future_imports=()) -> None:
+    def __init__(self, future_imports: Sequence[str] = ()) -> None:
         super().__init__(language='python', evaluator=PythonEvaluator(future_imports))


### PR DESCRIPTION
This makes `mypy --strict sybil/parsers/rest/codeblock.py` pass.