### PR TITLE
Avoid using private variable _unittest_reportflags from doctest

### DIFF
--- a/sybil/evaluators/doctest.py
+++ b/sybil/evaluators/doctest.py
@@ -1,7 +1,7 @@
 from doctest import (
     DocTest as BaseDocTest,
     DocTestRunner as BaseDocTestRunner,
-    _unittest_reportflags,
+    set_unittest_reportflags,
 )
 
 from sybil import Example
@@ -17,8 +17,11 @@ class DocTest(BaseDocTest):
 class DocTestRunner(BaseDocTestRunner):
 
     def __init__(self, optionflags) -> None:
-        optionflags |= _unittest_reportflags
+        old_doctest_unittest_reportflags = set_unittest_reportflags(0)
+        set_unittest_reportflags(old_doctest_unittest_reportflags)
+        optionflags |= old_doctest_unittest_reportflags
         BaseDocTestRunner.__init__(
+
             self,
             verbose=False,
             optionflags=optionflags,

--- a/sybil/evaluators/doctest.py
+++ b/sybil/evaluators/doctest.py
@@ -17,9 +17,9 @@ class DocTest(BaseDocTest):
 class DocTestRunner(BaseDocTestRunner):
 
     def __init__(self, optionflags) -> None:
-        old_doctest_unittest_reportflags = set_unittest_reportflags(0)
-        set_unittest_reportflags(old_doctest_unittest_reportflags)
-        optionflags |= old_doctest_unittest_reportflags
+        _unittest_reportflags = set_unittest_reportflags(0)
+        set_unittest_reportflags(_unittest_reportflags)
+        optionflags |= _unittest_reportflags
         BaseDocTestRunner.__init__(
 
             self,


### PR DESCRIPTION
Using private variables from a dependency increases risk of undesired behaviour change. mypy does not like the use of private variables from dependencies.

This change removes the use of _unittest_reportflags. Instead, it changes the code to get the old flags, by setting them to 0 (arbitrary), and then it sets them back.

Reading the code makes me think that this is a valid change, however, there is some risk as the tests are not thorough: even if I remove the line:

```python
optionflags |= old_doctest_unittest_reportflags
```

the tests still pass.