### PR TITLE
Specialise Pattern and Match type hints

### DIFF
--- a/sybil/document.py
+++ b/sybil/document.py
@@ -114,7 +114,7 @@ class Document:
 
     def find_region_sources(
         self, start_pattern: Pattern[str], end_pattern: Pattern[str]
-    ) -> Tuple[Match, Match, str]:
+    ) -> Iterator[Tuple[Match[str], Match[str], str]]:
         """
         This helper method can be used to extract source text
         for regions based on the two :ref:`regular expressions <re-objects>`

--- a/sybil/parsers/abstract/lexers.py
+++ b/sybil/parsers/abstract/lexers.py
@@ -38,7 +38,7 @@ class BlockLexer:
 
     def __init__(
             self,
-            start_pattern: Pattern,
+            start_pattern: Pattern[str],
             end_pattern_template: str,
             mapping: Optional[Dict[str, str]] = None,
     ) -> None:

--- a/sybil/parsers/abstract/skip.py
+++ b/sybil/parsers/abstract/skip.py
@@ -13,7 +13,7 @@ class AbstractSkipParser:
     #: Must return :class:`matches<typing.Match>` that contain two groups;
     #: group 1 containing an action of ``'next'``, ``'start'`` or ``'end'`` and group 2
     #: which should contain the source for an optional parenthesis-surrounded Python expression.
-    pattern: Pattern
+    pattern: Pattern[str]
 
     def __call__(self, document: Document) -> Iterable[Region]:
         for match in re.finditer(self.pattern, document.text):


### PR DESCRIPTION
This removes the following type of error from `mypy --strict sybil/`:

```
sybil/document.py:117: error: Missing type parameters for generic type "Match"  [type-arg]
```