### PR TITLE
mypy configuration and continuous integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ common: &common
               - "'pytest>=7.1,<7.4'"
               - "'pytest>=7.4'"
 
+    - python/typing:
+        packages: sybil
+
     - python/coverage:
         name: coverage
         requires:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+
+strict = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
 
 strict = True
-disable_error_code = union-attr
+disable_error_code = union-attr,return

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,7 @@
 
 strict = True
 disable_error_code = union-attr,return
+
+[mypy-sybil.integration.pytest]
+; This file is mainly pytest internals where unit tests catch things, not typing
+ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,4 @@
 [mypy]
 
 strict = True
+disable_error_code = union-attr

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     python_requires=">=3.7",
     extras_require=dict(
         test=[
+            'mypy',
             'myst_parser',
             'pytest>=7.1.0',
             'pytest-cov',


### PR DESCRIPTION
This allows us to run `mypy sybil/` and have shared expectations for what should pass.

Having this ready will also allow us to easily add global ignores, which we may do for `method-assign` soon.