### PR TITLE
Avoid using py.path.local

### DIFF
--- a/sybil/integration/pytest.py
+++ b/sybil/integration/pytest.py
@@ -14,7 +14,7 @@ from _pytest.nodes import Collector
 from _pytest.python import Module
 import pytest
 
-from ..example import SybilFailure
+from ..example import Example, SybilFailure
 from .. import example
 
 if TYPE_CHECKING:
@@ -42,7 +42,7 @@ class SybilFailureRepr(TerminalRepr):
 
 class SybilItem(pytest.Item):
 
-    def __init__(self, parent, sybil, example: example.Example) -> None:
+    def __init__(self, parent, sybil, example: Example) -> None:
         name = 'line:{},column:{}'.format(example.line, example.column)
         super(SybilItem, self).__init__(name, parent)
         self.example = example


### PR DESCRIPTION
If using `py.path.local`, we will have to skip errors regarding `py.path` for `mypy`. I chose to propose this change instead, as `py.path.local` is not the modern solution - `pathlib.Path` is.

The `mypy` errors that this removes:

```
sybil/integration/pytest.py:15: error: Skipping analyzing "py.path": module is installed, but missing library stubs or py.typed marker  [import-untyped]
sybil/integration/pytest.py:15: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
sybil/integration/pytest.py:15: error: Skipping analyzing "py": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

In `pytest` `7.0.0`, there were changes made which make this change possible.

See https://docs.pytest.org/en/7.1.x/changelog.html#id48. That changelog includes:

```
```

and:

```

pytest_collect_file - The file_path parameter (equivalent to existing path parameter).
```

I also brought in the exact type hint from the parent class's `reportinfo` method.

I did not change any tests as these will not be type checked.