### PR TITLE
Add a number of "assert <> is not None" for mypy

### DIFF
--- a/sybil/document.py
+++ b/sybil/document.py
@@ -130,6 +130,7 @@ class Document:
         for start_match in re.finditer(start_pattern, self.text):
             source_start = start_match.end()
             end_match = end_pattern.search(self.text, source_start)
+            assert end_match is not None
             source_end = end_match.start()
             source = self.text[source_start:source_end]
             yield start_match, end_match, source
@@ -177,8 +178,11 @@ class PythonDocStringDocument(PythonDocument):
             ):
                 continue
             node_start = line_offsets.get(docstring.lineno-1, docstring.col_offset)
+            assert docstring.end_lineno is not None
+            assert docstring.end_col_offset is not None
             node_end = line_offsets.get(docstring.end_lineno-1, docstring.end_col_offset)
             punc = DOCSTRING_PUNCTUATION.match(python_source_code, node_start, node_end)
+            assert punc is not None
             punc_size = len(punc.group(1))
             start = punc.end()
             end = node_end - punc_size

--- a/sybil/sybil.py
+++ b/sybil/sybil.py
@@ -94,7 +94,9 @@ class Sybil:
 
         self.parsers: Sequence[Parser] = parsers
         current_frame = inspect.currentframe()
+        assert current_frame is not None
         calling_frame = current_frame.f_back
+        assert calling_frame is not None
         calling_filename = inspect.getframeinfo(calling_frame).filename
         start_path = Path(calling_filename).parent / path
         self.path: Path = start_path.absolute()


### PR DESCRIPTION
This codebase uses multiple methods and properties which are typed as Optional, and makes the assumption that they are not None.

There are multiple ways of getting around this for the type checker. For example:

* `type: ignore` comments. A previous review comment explained that this is not wanted.
* `cast`.  A previous review comment explained that this is not wanted.
* `assert <> is not None`.  A previous review comment explained that this is not wanted.

I chose the latter as it is most to my taste.
I am open to specific suggestions for alternatives.