### PR TITLE
Fix type issues on sybil/parsers/abstract/codeblock.py

### DIFF
--- a/sybil/parsers/abstract/codeblock.py
+++ b/sybil/parsers/abstract/codeblock.py
@@ -32,14 +32,15 @@ class AbstractCodeBlockParser:
         if language is not None:
             self.language = language
         assert self.language, 'language must be specified!'
-        if evaluator is not None:
-            self.evaluate = evaluator
+        self._evaluator = evaluator
 
     def evaluate(self, example: Example) -> Optional[str]:
         """
         The :any:`Evaluator` used for regions yields by this parser can be provided by
         implementing this method.
         """
+        if self._evaluator is not None:
+            return self._evaluator(example)
         raise NotImplementedError
 
     def __call__(self, document: Document) -> Iterable[Region]:


### PR DESCRIPTION
This avoids the following issues.

```
sybil/parsers/abstract/codeblock.py:36: error: Cannot assign to a method  [method-assign]
sybil/parsers/abstract/codeblock.py:36: error: Incompatible types in assignment (expression has type "Callable[[Example], str | None]", variable has type "Callable[[Arg(Example, 'example')], str | None]")  [assignment]
```

I appreciate that the previous code works.
I'm open to specific suggestions - e.g. to ignore all `method-assign` errors.