### PR TITLE
Rename some `tb` variables

### DIFF
--- a/sybil/integration/pytest.py
+++ b/sybil/integration/pytest.py
@@ -84,18 +84,18 @@ class SybilItem(pytest.Item):
         def _traceback_filter(self, excinfo: ExceptionInfo[BaseException]) -> Traceback:
             traceback = excinfo.traceback
             tb = traceback.cut(path=example_module_path)
-            tb = tb[1]
-            if getattr(tb, '_rawentry', None) is not None:
-                traceback = Traceback(tb._rawentry)
+            tb_entry = tb[1]
+            if getattr(tb_entry, '_rawentry', None) is not None:
+                traceback = Traceback(tb_entry._rawentry)
             return traceback
 
     else:
 
         def _prunetraceback(self, excinfo):
             tb = excinfo.traceback.cut(path=example_module_path)
-            tb = tb[1]
-            if getattr(tb, '_rawentry', None) is not None:
-                excinfo.traceback = Traceback(tb._rawentry, excinfo)
+            tb_entry = tb[1]
+            if getattr(tb_entry, '_rawentry', None) is not None:
+                excinfo.traceback = Traceback(tb_entry._rawentry, excinfo)
 
     def repr_failure(
         self,


### PR DESCRIPTION
This avoids a mypy error where `tb` was referring to both a `Traceback` type and a `TracebackEntry` type.
To me, this is clearer as well.