### PR TITLE
Add py.typed package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     packages=find_packages(exclude=['tests', 'functional_tests']),
+    package_data={"sybil": ["py.typed"]},
     python_requires=">=3.7",
     extras_require=dict(
         test=[


### PR DESCRIPTION
This tells type checkers that the type annotations should be read from the Python implementation of `sybil`. See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages for an example description of adding `py.typed` to a project which uses `setuptools` and `setup.py`.

If you would really like CI to enforce this, look at using `pyright --verifytypes sybil`.