### PR TITLE
Ship py.typed with the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *.typed


### PR DESCRIPTION
Without this, users of the source distribution will hit mypy errors

See
https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages for mypy documentation which describes this.