### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,11 @@ common: &common
         matrix:
           parameters:
             image:
-              - cimg/python:3.7
               - cimg/python:3.8
               - cimg/python:3.9
               - cimg/python:3.11
               - cimg/python:3.12
             extra_packages:
-              - "'pytest>=7.1,<7.4'"
-              - "'pytest>=7.4,<8'"
               - "'pytest'"
 
     - python/typing:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     packages=find_packages(exclude=['tests', 'functional_tests']),
     package_data={"sybil": ["py.typed"]},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     extras_require=dict(
         test=[
             'mypy',

--- a/sybil/integration/pytest.py
+++ b/sybil/integration/pytest.py
@@ -53,21 +53,13 @@ class SybilItem(pytest.Item):
     def request_fixtures(self, names):
         # pytest fixtures dance:
         fm = self.session._fixturemanager
-        if PYTEST_VERSION >= (8, 0, 0):
-            closure = fm.getfixtureclosure(initialnames=names, parentnode=self, ignore_args=set())
-            names_closure, arg2fixturedefs = closure
-            fixtureinfo = FuncFixtureInfo(argnames=names, initialnames=names, names_closure=names_closure, name2fixturedefs=arg2fixturedefs)
-        else:
-            closure = fm.getfixtureclosure(names, self)
-            initialnames, names_closure, arg2fixturedefs = closure
-            fixtureinfo = FuncFixtureInfo(names, initialnames, names_closure, arg2fixturedefs)
+        closure = fm.getfixtureclosure(initialnames=names, parentnode=self, ignore_args=set())
+        names_closure, arg2fixturedefs = closure
+        fixtureinfo = FuncFixtureInfo(argnames=names, initialnames=names, names_closure=names_closure, name2fixturedefs=arg2fixturedefs)
         self._fixtureinfo = fixtureinfo
         self.funcargs = {}
-        if PYTEST_VERSION >= (8, 0, 0):
-            self._request = fixtures.TopRequest(pyfuncitem=self, _ispytest=True)
-            self.fixturenames = names_closure
-        else:
-            self._request = fixtures.FixtureRequest(self, _ispytest=True)
+        self._request = fixtures.TopRequest(pyfuncitem=self, _ispytest=True)
+        self.fixturenames = names_closure
 
     def reportinfo(self) -> Tuple[Union["os.PathLike[str]", str], Optional[int], str]:
         info = '%s line=%i column=%i' % (
@@ -89,23 +81,13 @@ class SybilItem(pytest.Item):
     def runtest(self) -> None:
         self.example.evaluate()
 
-    if PYTEST_VERSION >= (7, 4, 0):
-
-        def _traceback_filter(self, excinfo: ExceptionInfo[BaseException]) -> Traceback:
-            traceback = excinfo.traceback
-            tb = traceback.cut(path=example_module_path)
-            tb_entry = tb[1]
-            if getattr(tb_entry, '_rawentry', None) is not None:
-                traceback = Traceback(tb_entry._rawentry)
-            return traceback
-
-    else:
-
-        def _prunetraceback(self, excinfo):
-            tb = excinfo.traceback.cut(path=example_module_path)
-            tb_entry = tb[1]
-            if getattr(tb_entry, '_rawentry', None) is not None:
-                excinfo.traceback = Traceback(tb_entry._rawentry, excinfo)
+    def _traceback_filter(self, excinfo: ExceptionInfo[BaseException]) -> Traceback:
+        traceback = excinfo.traceback
+        tb = traceback.cut(path=example_module_path)
+        tb_entry = tb[1]
+        if getattr(tb_entry, '_rawentry', None) is not None:
+            traceback = Traceback(tb_entry._rawentry)
+        return traceback
 
     def repr_failure(
         self,

--- a/sybil/sybil.py
+++ b/sybil/sybil.py
@@ -6,11 +6,9 @@ from typing import Any, Dict, Sequence, Callable, Collection, Mapping, Optional,
 from .document import Document, PythonDocStringDocument, PythonDocument
 from .typing import Parser
 
-PY37_AND_EARLIER = sys.version_info[:2] <= (3, 7)
-
 DEFAULT_DOCUMENT_TYPES = {
     None: Document,
-    '.py': PythonDocument if PY37_AND_EARLIER else PythonDocStringDocument,
+    '.py': PythonDocStringDocument,
 }
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -288,8 +288,3 @@ def ast_docstrings(python_source_code: str) -> Sequence[str]:
         else:
             if docstring:
                 yield docstring
-
-
-def skip_if_37_or_older():
-    return pytest.mark.skipif(sys.version_info[:2] < (3, 8), reason="requires python3.8 or higher")
-

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -9,7 +9,7 @@ from sybil.document import Document, PythonDocStringDocument
 from sybil.example import SybilFailure
 from sybil.parsers.abstract import DocTestStringParser
 from sybil.parsers.rest import DocTestParser, DocTestDirectiveParser
-from .helpers import sample_path, parse, FUNCTIONAL_TEST_DIR, skip_if_37_or_older
+from .helpers import sample_path, parse, FUNCTIONAL_TEST_DIR
 
 
 def test_pass():
@@ -131,7 +131,6 @@ UNPARSEABLE = {
 MINIMUM_EXPECTED_DOCTESTS = 9
 
 
-@skip_if_37_or_older()
 def test_sybil_example_count(all_python_files):
     parser = DocTestStringParser()
 
@@ -149,7 +148,6 @@ def test_sybil_example_count(all_python_files):
 
 
 def check_sybil_against_doctest(path, text):
-    skip_if_37_or_older()
     problems = []
     name = str(path)
     regions = list(DocTestStringParser()(text, path))
@@ -177,7 +175,6 @@ def test_all_docstest_examples_extracted_from_source_correctly(python_file):
     check_sybil_against_doctest(path, source)
 
 
-@skip_if_37_or_older()
 def test_all_docstest_examples_extracted_from_docstrings_correctly(python_file):
     path, source = python_file
     for start, end, docstring in PythonDocStringDocument.extract_docstrings(source):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -12,10 +12,9 @@ from sybil import Region, Example
 from sybil.document import PythonDocStringDocument, Document
 from sybil.example import NotEvaluated, SybilFailure
 from sybil.exceptions import LexingException
-from .helpers import ast_docstrings, skip_if_37_or_older, parse, sample_path
+from .helpers import ast_docstrings, parse, sample_path
 
 
-@skip_if_37_or_older()
 def test_extract_docstring():
     """
     This is a function docstring.
@@ -27,7 +26,6 @@ def test_extract_docstring():
     compare(expected, actual=[python_source_code[s:e] for s, e, _ in actual], show_whitespace=True)
 
 
-@skip_if_37_or_older()
 def test_all_docstrings_extracted_correctly(python_file):
     problems = []
     path, source = python_file

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -10,7 +10,7 @@ from sybil.parsers.rest import PythonCodeBlockParser, DocTestParser
 from sybil.python import import_cleanup
 from .helpers import (
     run_pytest, run_unittest, PYTEST, run, write_config, UNITTEST, write_doctest,
-    functional_sample, clone_functional_sample, skip_if_37_or_older, check_path, sample_path
+    functional_sample, clone_functional_sample, check_path, sample_path
 )
 
 
@@ -339,7 +339,6 @@ def test_modules_not_importable_unittest(tmp_path: Path, capsys: CaptureFixture[
     out.then_find("ModuleNotFoundError: No module named 'b'")
 
 
-@skip_if_37_or_older()
 @pytest.mark.parametrize('runner', [PYTEST, UNITTEST])
 def test_package_and_docs(tmp_path: Path, capsys: CaptureFixture[str], runner: str):
     root = clone_functional_sample('package_and_docs', tmp_path)
@@ -468,7 +467,6 @@ def test_markdown(capsys: CaptureFixture[str], runner: str):
     out.then_find("Exception: boom!")
 
 
-@skip_if_37_or_older()
 def test_codeblock_with_protocol_then_doctest():
     sybil = Sybil([PythonCodeBlockParser(), DocTestParser()])
     check_path(sample_path('protocol-typing.rst'), sybil, expected=3)


### PR DESCRIPTION
This implies pytest 8 or newer, since pytest 7 was the last to support Python 3.7