### PR TITLE
Satisfy pyright --verifytypes by changing how Lexeme.__init__ is written

### DIFF
--- a/sybil/region.py
+++ b/sybil/region.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, Optional
+from typing import Any, Optional
 
 from sybil.typing import Evaluator, LexemeMapping
 
@@ -14,7 +14,9 @@ class Lexeme(str):
         return str.__new__(cls, text)
 
     def __init__(self, text: str, offset: int, line_offset: int) -> None:
-        self.text, self.offset, self.line_offset = text, offset, line_offset
+        self.text = text
+        self.offset = offset
+        self.line_offset = line_offset
 
     def strip_leading_newlines(self) -> 'Lexeme':
         stripped = self.lstrip('\n')


### PR DESCRIPTION
I am writing a project which includes a new Sybil evaluator. I use `pyright --verifytypes` on my projects to verify that the projects are type complete.

From https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#type-completeness:

```
A “py.typed” library is said to be “type complete” if all of the symbols that comprise its interface have type annotations that refer to types that are fully known. Private symbols are exempt.
```

As this project makes a new Sybil evaluator public, the `Evaluator` type is therefore part of the public interface of my project.

When I run `pyright --verifytypes` I get errors which boil down the following:

```
sybil/region.py:17:14 - error: Type is missing type annotation and could be inferred differently by type checkers
    Inferred type is "str"
sybil.region.Lexeme.offset
```

and similar.

I appreciate that Sybil does not use `pyright` or `--verifytypes`, and honestly I do not understand this error really.
Perhaps it is stating that type checkers are not all going to unpack tuple types.

I hope that this change is still acceptable, therefore giving my project the ability (for now) to have `--verifytypes` work.