### PR TITLE
Avoid ast deprecations

### DIFF
--- a/sybil/document.py
+++ b/sybil/document.py
@@ -1,11 +1,11 @@
 import ast
 import re
-from ast import AsyncFunctionDef, FunctionDef, ClassDef, Module, Expr, Constant, Str
+from ast import AsyncFunctionDef, FunctionDef, ClassDef, Constant, Module, Expr
 from bisect import bisect
 from io import open
 from itertools import chain
 from pathlib import Path
-from typing import Any, Dict, cast
+from typing import Any, Dict
 from typing import List, Iterator, Pattern, Tuple, Match
 
 from .example import Example, SybilFailure, NotEvaluated
@@ -221,8 +221,8 @@ class PythonDocStringDocument(PythonDocument):
             if not (node.body and isinstance(node.body[0], Expr)):
                 continue
             docstring = node.body[0].value
-            if isinstance(docstring, Str):
-                text = docstring.s
+            if isinstance(docstring, Constant):
+                text = docstring.value
             else:
                 continue
             node_start = line_offsets.get(docstring.lineno-1, docstring.col_offset)


### PR DESCRIPTION
Without this change I got:

```
/Users/adam/.virtualenvs/requests-mock-flask/lib/python3.12/site-packages/sybil/document.py:224: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    if isinstance(docstring, Str):

../../../.virtualenvs/requests-mock-flask/lib/python3.12/site-packages/sybil/document.py:225
../../../.virtualenvs/requests-mock-flask/lib/python3.12/site-packages/sybil/document.py:225
  /Users/adam/.virtualenvs/requests-mock-flask/lib/python3.12/site-packages/sybil/document.py:225: DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead
    text = docstring.s
```