### PR TITLE
deal with pytest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,26 @@ common: &common
 
     - python/pip-run-tests:
         matrix:
+          alias: "python-versions"
           parameters:
             image:
               - cimg/python:3.8
               - cimg/python:3.9
               - cimg/python:3.11
               - cimg/python:3.12
+
+    - python/pip-run-tests:
+        matrix:
+          alias: "pytest-versions"
+          parameters:
+            image:
+              - cimg/python:3.12
+            extras:
+              - "[test,pytest]"
             extra_packages:
-              - "'pytest'"
+              - "'pytest>=7.1,<7.4'"
+              - "'pytest>=7.4,<8'"
+              - "'pytest>=8'"
 
     - python/typing:
         packages: sybil
@@ -23,7 +35,8 @@ common: &common
     - python/coverage:
         name: coverage
         requires:
-          - python/pip-run-tests
+          - "python-versions"
+          - "pytest-versions"
 
     - python/release:
         name: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,10 @@ common: &common
             extras:
               - "[test,pytest]"
             extra_packages:
-              - "'pytest>=7.1,<7.4'"
-              - "'pytest>=7.4,<8'"
-              - "'pytest>=8'"
+              # No known problems around 8.3, these are here to provide
+              # syntax examples and ensure the matrix still works:
+              - "'pytest>=8,<8.3'"
+              - "'pytest>=8.3'"
 
     - python/typing:
         packages: sybil

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changes
 
 - Drop Python 3.7 support.
 
+- Drop support for pytest versions less than 8.
+
 - :class:`Sybil` now takes a name which is used in any test identifiers it produces.
 
 - Add support for :rst:dir:`code` and :rst:dir:`sourcecode` directives in both ReST and MyST.

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -18,6 +18,15 @@ will be tested. They use :ref:`doctests <doctest-simple-testfile>`,
 pytest
 ~~~~~~
 
+You should install Sybil with the ``pytest`` extra, to ensure
+you have a compatible version of `pytest`__:
+
+__ https://docs.pytest.org
+
+.. code-block:: bash
+
+  pip install sybil[pytest]
+
 To have `pytest`__ check the examples, Sybil makes use of the
 ``pytest_collect_file`` hook. To use this, configuration is placed in
 a ``confest.py`` in your documentation source directory, as shown below.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,6 +1,16 @@
 Quickstart
 ==========
 
+Sybil is installed as a standard Python package in whatever way works best for you.
+If you're using it with `pytest`__, you should install it with the ``pytest`` extra, to ensure
+you have compatible versions:
+
+__ https://docs.pytest.org
+
+.. code-block:: bash
+
+  pip install sybil[pytest]
+
 Here's how you would set up a ``conftest.py`` in the root of your
 project such that running `pytest`__ would check examples in your project's source code
 and `Sphinx`__ source. Python :rst:dir:`code-block` and :ref:`doctest <doctest-simple-testfile>`

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ from setuptools import setup, find_packages
 
 base_dir = os.path.dirname(__file__)
 
+PYTEST_VERSION_SPEC = 'pytest>=8'
+
 setup(
     name='sybil',
     version='7.0.0',
@@ -25,10 +27,11 @@ setup(
     package_data={"sybil": ["py.typed"]},
     python_requires=">=3.8",
     extras_require=dict(
+        pytest=[PYTEST_VERSION_SPEC],
         test=[
             'mypy',
             'myst_parser',
-            'pytest>=7.1.0',
+            PYTEST_VERSION_SPEC,
             'pytest-cov',
             'seedir',
             'testfixtures',


### PR DESCRIPTION
Introduce a `pytest` extra, so give some possibility of ensuring the versions of pytest and sybil installed are compatible.

This is in response to https://github.com/simplistix/sybil/issues/128 and also forgetting to mention that pytest 8 was the minimum supported version as of sybil 7.

@adamtheturtle: I think this partially addresses your concerns in https://github.com/simplistix/sybil/issues/82.
I'm still negative on adding an upper bound in the requirement: 
- I've been bitten too many times by pytest changing "internals" that packages like Sybil are forced to use in second or third point versions
- I'll likely miss new major versions of pytest coming out, and I don't want to artificially pin either my own projects or others to an older version of pytest because of this