### PR TITLE
Move from typing to collections.abc for multiple deprecated imports

### DIFF
--- a/sybil/document.py
+++ b/sybil/document.py
@@ -2,11 +2,12 @@ import ast
 import re
 from ast import AsyncFunctionDef, FunctionDef, ClassDef, Constant, Module, Expr
 from bisect import bisect
+from collections.abc import Iterator
 from io import open
 from itertools import chain
 from pathlib import Path
 from typing import Any, Dict
-from typing import List, Iterator, Pattern, Tuple, Match
+from typing import List, Pattern, Tuple, Match
 
 from .example import Example, SybilFailure, NotEvaluated
 from .exceptions import LexingException

--- a/sybil/evaluators/python.py
+++ b/sybil/evaluators/python.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 import __future__
 
 from sybil import Example

--- a/sybil/integration/pytest.py
+++ b/sybil/integration/pytest.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 
 import os
+from collections.abc import Callable, Sequence
 from inspect import getsourcefile
 from os.path import abspath
 from pathlib import Path
-from typing import Callable, Union, Tuple, Optional, Sequence, List
+from typing import Union, Tuple, Optional, List
 
 import pytest
 from pytest import Collector, ExceptionInfo, Module, Session

--- a/sybil/integration/unittest.py
+++ b/sybil/integration/unittest.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, Optional
+from collections.abc import Callable
+from typing import Any, Dict, Optional
 from unittest import TestCase as BaseTestCase, TestSuite
 from unittest.loader import TestLoader
 

--- a/sybil/parsers/abstract/clear.py
+++ b/sybil/parsers/abstract/clear.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 from sybil import Document, Region, Example
 from sybil.parsers.abstract.lexers import LexerCollection

--- a/sybil/parsers/abstract/codeblock.py
+++ b/sybil/parsers/abstract/codeblock.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Sequence, Optional, Callable
+from collections.abc import Iterable, Sequence, Callable
+from typing import Optional
 
 from sybil import Region, Document, Example
 from sybil.typing import Evaluator, Lexer, Parser

--- a/sybil/parsers/abstract/doctest.py
+++ b/sybil/parsers/abstract/doctest.py
@@ -1,8 +1,8 @@
+from collections.abc import Iterable
 from doctest import (
     DocTestParser as BaseDocTestParser,
     Example as DocTestExample,
 )
-from typing import Iterable
 
 from sybil.evaluators.doctest import DocTestEvaluator
 from sybil.region import Region
@@ -51,5 +51,3 @@ class DocTestStringParser(BaseDocTestParser):
             lineno += string.count('\n', m.start(), m.end())
             # Update charno.
             charno = m.end()
-
-

--- a/sybil/parsers/abstract/lexers.py
+++ b/sybil/parsers/abstract/lexers.py
@@ -1,7 +1,8 @@
 import re
 import textwrap
 from itertools import chain
-from typing import Optional, Dict, Iterable, Pattern, List
+from collections.abc import Iterable
+from typing import Optional, Dict, Pattern, List
 
 from sybil import Document
 from sybil.exceptions import LexingException

--- a/sybil/parsers/abstract/skip.py
+++ b/sybil/parsers/abstract/skip.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 from sybil import Document, Region
 from sybil.evaluators.skip import Skipper

--- a/sybil/parsers/capture.py
+++ b/sybil/parsers/capture.py
@@ -1,5 +1,5 @@
 # THIS MODULE IS FOR BACKWARDS COMPATIBILITY ONLY!
-from typing import Iterable
+from collections.abc import Iterable
 
 from sybil import Region, Document
 from sybil.parsers.rest import CaptureParser

--- a/sybil/parsers/markdown/lexers.py
+++ b/sybil/parsers/markdown/lexers.py
@@ -1,5 +1,6 @@
 import re
-from typing import Optional, Dict, Pattern, Iterable, Match, List
+from collections.abc import Iterable
+from typing import Optional, Dict, Pattern, Match, List
 
 from sybil import Document, Region, Lexeme
 from sybil.parsers.abstract.lexers import BlockLexer, strip_prefix

--- a/sybil/parsers/myst/doctest.py
+++ b/sybil/parsers/myst/doctest.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from sybil import Document, Region
 from sybil.evaluators.doctest import DocTestEvaluator
@@ -25,4 +25,3 @@ class DocTestDirectiveParser:
             for region in self.string_parser(source, document.path):
                 region.adjust(lexed_region, source)
                 yield region
-

--- a/sybil/parsers/myst/lexers.py
+++ b/sybil/parsers/myst/lexers.py
@@ -1,5 +1,6 @@
 import re
-from typing import Optional, Dict, Iterable
+from collections.abc import Iterable
+from typing import Optional, Dict
 
 from sybil import Document, Region
 from sybil.parsers.abstract.lexers import BlockLexer
@@ -119,5 +120,3 @@ class DirectiveInPercentCommentLexer(BlockLexer):
             end_pattern_template=DIRECTIVE_IN_PERCENT_COMMENT_END,
             mapping=mapping,
         )
-
-

--- a/sybil/parsers/rest/capture.py
+++ b/sybil/parsers/rest/capture.py
@@ -1,6 +1,7 @@
 import re
 import string
-from typing import Iterable, List, Tuple
+from collections.abc import Iterable
+from typing import List, Tuple
 from textwrap import dedent
 
 from sybil import Region, Document

--- a/sybil/parsers/rest/codeblock.py
+++ b/sybil/parsers/rest/codeblock.py
@@ -1,8 +1,10 @@
+from collections.abc import Sequence
+from typing import Optional
+
 from sybil.evaluators.python import pad, PythonEvaluator
 from sybil.parsers.abstract import AbstractCodeBlockParser
 from sybil.parsers.rest.lexers import DirectiveLexer, DirectiveInCommentLexer
 from sybil.typing import Evaluator
-from typing import Optional, Sequence
 
 
 class CodeBlockParser(AbstractCodeBlockParser):

--- a/sybil/parsers/rest/doctest.py
+++ b/sybil/parsers/rest/doctest.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from sybil import Document, Region
 from sybil.evaluators.doctest import DocTestEvaluator

--- a/sybil/parsers/rest/lexers.py
+++ b/sybil/parsers/rest/lexers.py
@@ -1,5 +1,6 @@
 import re
-from typing import Optional, Dict, Iterable
+from collections.abc import Iterable
+from typing import Optional, Dict
 
 from sybil import Document, Region
 from sybil.parsers.abstract.lexers import BlockLexer

--- a/sybil/parsers/skip.py
+++ b/sybil/parsers/skip.py
@@ -1,5 +1,5 @@
 # THIS MODULE IS FOR BACKWARDS COMPATIBILITY ONLY!
-from typing import Iterable
+from collections.abc import Iterable
 
 from sybil import Region, Document
 from .rest import SkipParser

--- a/sybil/python.py
+++ b/sybil/python.py
@@ -1,8 +1,8 @@
 import importlib
 import sys
+from collections.abc import Iterator
 from contextlib import contextmanager
 from types import ModuleType
-from typing import Iterator
 
 from pathlib import Path
 

--- a/sybil/sybil.py
+++ b/sybil/sybil.py
@@ -1,6 +1,7 @@
 import inspect
 from pathlib import Path
-from typing import Any, Dict, Sequence, Callable, Collection, Mapping, Optional, Type, List, Tuple
+from collections.abc import Callable, Collection, Mapping, Sequence
+from typing import Any, Dict, Optional, Type, List, Tuple
 
 from .document import Document, PythonDocStringDocument
 from .example import Example

--- a/sybil/typing.py
+++ b/sybil/typing.py
@@ -1,4 +1,5 @@
-from typing import Callable, TYPE_CHECKING, Iterable, Optional, Any, Dict
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Optional, Any, Dict
 
 if TYPE_CHECKING:
     import sybil

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,6 @@
 import ast
 import sys
+from collections.abc import Sequence, Iterable
 from contextlib import contextmanager
 from os.path import dirname, join
 from pathlib import Path
@@ -7,7 +8,7 @@ from shutil import copytree
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 from traceback import TracebackException
-from typing import Optional, Tuple, List, Sequence, Union, Iterable
+from typing import Optional, Tuple, List, Union
 from unittest import TextTestRunner, main as unittest_main, SkipTest
 
 from pytest import CaptureFixture, ExceptionInfo, main as pytest_main

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -4,7 +4,7 @@ This is a module doc string.
 import re
 from functools import partial
 from pathlib import Path
-from typing import Iterable
+from collections.abc import Iterable
 
 from testfixtures import compare, ShouldRaise
 
@@ -54,7 +54,7 @@ def test_evaluator_returns_non_string():
         yield Region(0, 1, None, evaluator)
 
     examples, namespace = parse('sample1.txt', parser, expected=1)
-    with ShouldRaise(SybilFailure(examples[0], f'NotEvaluated()')):
+    with ShouldRaise(SybilFailure(examples[0], 'NotEvaluated()')):
         examples[0].evaluate()
 
 


### PR DESCRIPTION
typing.Callable and others are deprecated and may get removed (earliest October 2025). See "Importing those from typing is deprecated." and the list of items above it, in https://peps.python.org/pep-0585/#implementation.