### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ common: &common
           alias: "python-versions"
           parameters:
             image:
-              - cimg/python:3.8
               - cimg/python:3.9
               - cimg/python:3.11
               - cimg/python:3.12

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Next
+----
+
+- Drop Python 3.8 support.
+
 7.1.1 (16 Sep 2024)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     packages=find_packages(exclude=['tests', 'functional_tests']),
     package_data={"sybil": ["py.typed"]},
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     extras_require=dict(
         pytest=[PYTEST_VERSION_SPEC],
         test=[

--- a/sybil/typing.py
+++ b/sybil/typing.py
@@ -15,7 +15,6 @@ Lexer = Callable[['sybil.Document'], Iterable['sybil.Region']]
 #: The signature for a :term:`parser`.
 Parser = Callable[['sybil.Document'], Iterable['sybil.Region']]
 
-# In the future, this could likely be a TypedDict when Python 3.8 is the minimum supported version
+# This could likely be a TypedDict.
 #: Mappings used to store lexemes for a :class:`~sybil.Region`.
 LexemeMapping = Dict[str, Any]
-


### PR DESCRIPTION
Python 3.8 will be EOL in October 2024: https://devguide.python.org/versions/#supported-versions

Follow-up PRs will update the code to make use of Python 3.9+ features.