### PR TITLE
Move from some _pytest imports to pytest imports

### DIFF
--- a/sybil/integration/pytest.py
+++ b/sybil/integration/pytest.py
@@ -7,13 +7,11 @@ from pathlib import Path
 from typing import Callable, Union, Tuple, Optional, Sequence, List
 
 import pytest
+from pytest import Collector, ExceptionInfo, Module, Session
 from _pytest import fixtures
-from _pytest._code.code import TerminalRepr, Traceback, ExceptionInfo
+from _pytest._code.code import TerminalRepr, Traceback
 from _pytest._io import TerminalWriter
 from _pytest.fixtures import FuncFixtureInfo
-from _pytest.main import Session
-from _pytest.nodes import Collector
-from _pytest.python import Module
 
 from sybil import example as example_module, Sybil, Document
 from sybil.example import Example

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,9 +10,7 @@ from traceback import TracebackException
 from typing import Optional, Tuple, List, Sequence, Union, Iterable
 from unittest import TextTestRunner, main as unittest_main, SkipTest
 
-from _pytest._code import ExceptionInfo
-from _pytest.capture import CaptureFixture
-from _pytest.config import main as pytest_main
+from pytest import CaptureFixture, ExceptionInfo, main as pytest_main
 from seedir import seedir
 from testfixtures import compare
 


### PR DESCRIPTION
These are now public interfaces.
I believe that using the public interfaces makes it less likely that pytest minor bumps will break Sybil (e.g. with code moving between files).