### PR TITLE
Enable running skips with custom marker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+Next
+----
+
+- Introduce the ``directive`` option to :class:``sybil.parsers.myst.SkipParser``,
+  :class:``sybil.parsers.markdown.SkipParser`` and :class:``sybil.parsers.rest.SkipParser``
+  to allow for skipping particular code blocks.
+
 8.0.0 (20 Sep 2024)
 -------------------
 

--- a/docs/markdown.rst
+++ b/docs/markdown.rst
@@ -216,6 +216,8 @@ The above examples could be checked with the following configuration:
       expected_skips=('not yet working', 'Fix in v5', 'Fix in v5'),
   )
 
+Use the ``directive`` argument to :class:`sybil.parsers.markdown.SkipParser` to skip examples using a directive other than ``"skip"``.
+
 .. _markdown-clear-namespace:
 
 Clearing the namespace

--- a/docs/myst.rst
+++ b/docs/myst.rst
@@ -287,6 +287,8 @@ The above examples could be checked with the following configuration:
       expected_skips=('not yet working', 'Fix in v5', 'Fix in v5'),
   )
 
+Use the ``directive`` argument to :class:`sybil.parsers.myst.SkipParser` to skip examples using a directive other than ``"skip"``.
+
 .. _myst-clear-namespace:
 
 Clearing the namespace

--- a/docs/rest.rst
+++ b/docs/rest.rst
@@ -336,6 +336,8 @@ The above examples could be checked with the following configuration:
       expected_skips=('not yet working', 'Fix in v5', 'Fix in v5'),
   )
 
+Use the ``directive`` argument to :class:`sybil.parsers.rest.SkipParser` to skip examples using a directive other than ``"skip"``.
+
 .. _clear-namespace:
 
 Clearing the namespace

--- a/sybil/parsers/markdown/skip.py
+++ b/sybil/parsers/markdown/skip.py
@@ -7,7 +7,7 @@ class SkipParser(AbstractSkipParser):
     A :any:`Parser` for :ref:`skip <markdown-skip-parser>` instructions.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, directive: str = 'skip') -> None:
         super().__init__([
-            DirectiveInHTMLCommentLexer('skip'),
+            DirectiveInHTMLCommentLexer(directive=directive),
         ])

--- a/sybil/parsers/myst/skip.py
+++ b/sybil/parsers/myst/skip.py
@@ -8,8 +8,8 @@ class SkipParser(AbstractSkipParser):
     A :any:`Parser` for :ref:`skip <myst-skip-parser>` instructions.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, directive: str = 'skip') -> None:
         super().__init__([
-            DirectiveInPercentCommentLexer('skip'),
-            DirectiveInHTMLCommentLexer('skip'),
+            DirectiveInPercentCommentLexer(directive=directive),
+            DirectiveInHTMLCommentLexer(directive=directive),
         ])

--- a/sybil/parsers/rest/skip.py
+++ b/sybil/parsers/rest/skip.py
@@ -7,5 +7,5 @@ class SkipParser(AbstractSkipParser):
     A :any:`Parser` for :ref:`skip <skip-parser>` instructions.
     """
 
-    def __init__(self) -> None:
-        super().__init__([DirectiveInCommentLexer('skip')])
+    def __init__(self, directive: str = 'skip') -> None:
+        super().__init__([DirectiveInCommentLexer(directive=directive)])

--- a/tests/samples/skip-custom-directive.txt
+++ b/tests/samples/skip-custom-directive.txt
@@ -1,0 +1,41 @@
+.. invisible-code-block: python
+
+  run = []
+
+Let's use the default "skip" marker, which should not skip anything:
+
+.. skip: next
+
+.. code-block:: python
+
+  run.append(1)
+
+.. skip: start
+
+.. invisible-code-block: python
+
+  run.append(2)
+
+.. skip: end
+
+.. custom-skip-marker: start
+
+These should not:
+
+.. code-block:: python
+
+  run.append(3)
+
+Nor this one:
+
+.. code-block:: python
+
+  run.append(4)
+
+.. custom-skip-marker: end
+
+But this one should:
+
+.. code-block:: python
+
+  run.append(5)

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -105,3 +105,9 @@ def test_next_follows_next():
     for example in examples:
         example.evaluate()
     assert result == [1]
+
+def test_skip_custom_directive():
+    examples, namespace = parse('skip-custom-directive.txt', PythonCodeBlockParser(), SkipParser('custom-skip-marker'), expected=8)
+    for example in examples:
+        example.evaluate()
+    assert namespace['run'] == [1, 2, 5]


### PR DESCRIPTION
I want to have two `Sybil`s, and for a code block to be skipped only for one of those `Sybil`s. This is my attempt to get that working.