### PR TITLE
Add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 _build/
 .*cache/
 pytestdebug.log
+__pycache__/


### PR DESCRIPTION
I found when running `pytest` that these got in the way of my Git status.