### PR TITLE
Add type hints to AbstractSkipParser instance variables

### DIFF
--- a/sybil/parsers/abstract/skip.py
+++ b/sybil/parsers/abstract/skip.py
@@ -19,8 +19,8 @@ class AbstractSkipParser:
     """
 
     def __init__(self, lexers: Sequence[Lexer]):
-        self.lexers = LexerCollection(lexers)
-        self.skipper = Skipper()
+        self.lexers: LexerCollection = LexerCollection(lexers)
+        self.skipper: Skipper = Skipper()
 
     def __call__(self, document: Document) -> Iterable[Region]:
         for lexed in self.lexers(document):


### PR DESCRIPTION
In [sybil_extras](https://github.com/adamtheturtle/sybil-extras/) I ship classes which subclass `AbstractSkipParser`. I want to verify the types on `sybil_extras`'s public interface by using `pyright --verifytypes sybil_extras`. This fails because `pyright` considers `AbstractSkipParser`'s instance variable types to be ambiguous:

```
Symbols used in public interface:
sybil_extras.parsers.markdown.custom_directive_skip.CustomDirectiveSkipParser
   error: Type of base class "sybil.parsers.abstract.skip.AbstractSkipParser" is partially unknown
sybil.parsers.abstract.skip.AbstractSkipParser.lexers
  /Users/adam/Documents/repositories/sybil-extras/.venv/lib/python3.13/site-packages/sybil/parsers/abstract/skip.py:22:14 - error: Type is missing type annotation and could be inferred differently by type checkers
    Inferred type is "LexerCollection"
sybil.parsers.abstract.skip.AbstractSkipParser.skipper
  /Users/adam/Documents/repositories/sybil-extras/.venv/lib/python3.13/site-packages/sybil/parsers/abstract/skip.py:23:14 - error: Type is missing type annotation and could be inferred differently by type checkers
    Inferred type is "Skipper"
sybil_extras.parsers.myst.custom_directive_skip.CustomDirectiveSkipParser
   error: Type of base class "sybil.parsers.abstract.skip.AbstractSkipParser" is partially unknown
sybil_extras.parsers.rest.custom_directive_skip.CustomDirectiveSkipParser
   error: Type of base class "sybil.parsers.abstract.skip.AbstractSkipParser" is partially unknown
```

`pyright` follows the official type hinting specs quite closely, and considers instance variables without explicit types to be ambiguous. See https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#ambiguous-types.