### PR TITLE
Raise clear ValueError rather than TypeError when arguments are not g…

### DIFF
--- a/sybil/parsers/abstract/skip.py
+++ b/sybil/parsers/abstract/skip.py
@@ -28,8 +28,7 @@ class AbstractSkipParser:
         for lexed in self.lexers(document):
             arguments = lexed.lexemes['arguments']
             if arguments is None:
-                directive = lexed.lexemes.get('directive', 'skip')
-                raise ValueError(f'missing arguments to {directive}')
+                raise ValueError(f'missing arguments to {self.directive}')
             match = SKIP_ARGUMENTS_PATTERN.match(arguments)
             if match is None:
                 raise ValueError(f'malformed arguments to {self.directive}: {arguments!r}')

--- a/sybil/parsers/abstract/skip.py
+++ b/sybil/parsers/abstract/skip.py
@@ -25,6 +25,9 @@ class AbstractSkipParser:
     def __call__(self, document: Document) -> Iterable[Region]:
         for lexed in self.lexers(document):
             arguments = lexed.lexemes['arguments']
+            if arguments is None:
+                directive = lexed.lexemes.get('directive', 'skip')
+                raise ValueError(f'missing arguments to {directive}')
             match = SKIP_ARGUMENTS_PATTERN.match(arguments)
             if match is None:
                 directive = lexed.lexemes.get('directive', 'skip')

--- a/tests/samples/skip-missing-arguments.txt
+++ b/tests/samples/skip-missing-arguments.txt
@@ -1,0 +1,3 @@
+.. skip:
+
+  There are no arguments above

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -112,3 +112,8 @@ def test_malformed_arguments():
     path = sample_path('skip-malformed-arguments.txt')
     with ShouldRaise(ValueError("malformed arguments to skip: '<:'")):
         Document.parse(path, SkipParser())
+
+def test_missing_arguments():
+    path = sample_path('skip-missing-arguments.txt')
+    with ShouldRaise(ValueError("missing arguments to skip")):
+        Document.parse(path, SkipParser())


### PR DESCRIPTION
…iven to a skip

This error is more consistent with the `ValueError` raised if the arguments are malformed.

I am writing a CLI on top of Sybil and if a `.. skip:` is given with no arguments, I want to catch an exception and for the CLI to error gracefully. Right now all I have is a `TypeError` with the message "expected string or bytes-like object, got 'NoneType'."

If this is accepted in principle, I can add a test for it.