### PR TITLE
Add support for myst code-cell directive

### DIFF
--- a/docs/examples/myst/codeblock-python-code-cell.md
+++ b/docs/examples/myst/codeblock-python-code-cell.md
@@ -1,0 +1,22 @@
+% invisible-code-block: python
+%
+%  # This could be some state setup needed to demonstrate things
+% initialized = True
+
+This fenced code block defines a function:
+
+```python
+
+    def prefix(text: str) -> str:
+        return 'prefix: '+text
+```
+
+This MyST `code-cell` directive then uses it:
+
+```{code-cell} python
+    prefixed = prefix('some text')
+```
+
+<!--- invisible-code-block: python
+assert prefixed == 'prefix: some text', prefixed
+--->

--- a/docs/myst.rst
+++ b/docs/myst.rst
@@ -12,7 +12,8 @@ doctest
 
 A selection of parsers are included that can extract and check doctest examples in
 ``python`` `fenced code blocks`__,
-MyST ``code-block`` :ref:`directives <syntax/directives>` and
+MyST ``code-block`` :ref:`directives <syntax/directives>`,
+MyST ``code-cell`` :ref:`directives <syntax/directives>`, and
 MyST ``doctest`` :ref:`directives <syntax/directives>`.
 
 __ https://spec.commonmark.org/0.30/#fenced-code-blocks
@@ -137,16 +138,18 @@ Code blocks
 -----------
 
 The codeblock parsers extract examples from `fenced code blocks`__,
-MyST ``code-block`` :ref:`directives <syntax/directives>` and "invisible"
+MyST ``code-block`` :ref:`directives <syntax/directives>`, MyST ``code-cell`` 
+:ref:`directives <syntax/directives>` (used by `mystmd`__), and "invisible"
 code blocks in both styles of Markdown mult-line comment.
 
 __ https://spec.commonmark.org/0.30/#fenced-code-blocks
+__ https://mystmd.org/
 
 Python
 ~~~~~~
 
-Python examples can be checked in either ``python`` `fenced code blocks`__ or
-MyST ``code-block`` :ref:`directives <syntax/directives>` using the
+Python examples can be checked in either ``python`` `fenced code blocks`__,
+MyST ``code-block``, or MyST ``code-cell`` :ref:`directives <syntax/directives>` using the
 :class:`sybil.parsers.myst.PythonCodeBlockParser`.
 
 __ https://spec.commonmark.org/0.30/#fenced-code-blocks
@@ -172,6 +175,19 @@ These examples can be checked with the following configuration:
 
   from tests.helpers import check_path
   check_path('examples/myst/codeblock-python.md', sybil, expected=4)
+
+The ``code-cell`` directive, which is used by `mystmd`__ for Jupyter notebook integration,
+is also supported:
+
+__ https://mystmd.org/
+
+.. literalinclude:: examples/myst/codeblock-python-code-cell.md
+  :language: markdown
+
+.. invisible-code-block: python
+
+  from tests.helpers import check_path
+  check_path('examples/myst/codeblock-python-code-cell.md', sybil, expected=4)
 
 
 .. _myst-codeblock-other:

--- a/sybil/parsers/myst/codeblock.py
+++ b/sybil/parsers/myst/codeblock.py
@@ -31,7 +31,7 @@ class CodeBlockParser(AbstractCodeBlockParser):
                     mapping={'language': 'arguments', 'source': 'source'},
                 ),
                 DirectiveLexer(
-                    directive=r'(sourcecode|code-block|code)',
+                    directive=r'(sourcecode|code-block|code-cell|code)',
                     arguments='.+',
                 ),
                 DirectiveInPercentCommentLexer(

--- a/tests/samples/myst-code-cell.md
+++ b/tests/samples/myst-code-cell.md
@@ -1,0 +1,6 @@
+This is a code-cell block with an extra flag:
+
+```{code-cell} python
+:hide-code:
+assert 1 + 1 == 2
+```

--- a/tests/test_myst_codeblock.py
+++ b/tests/test_myst_codeblock.py
@@ -210,3 +210,8 @@ def test_code_directive():
 def test_sourcecode_directive():
     sybil = Sybil([PythonCodeBlockParser()])
     check_path(sample_path('myst-sourcecode.md'), sybil, expected=1)
+
+
+def test_code_cell_directive():
+    sybil = Sybil([PythonCodeBlockParser()])
+    check_path(sample_path('myst-code-cell.md'), sybil, expected=1)


### PR DESCRIPTION
According to the [canonical reference](https://mystmd.org/guide/notebooks-with-markdown), MyST expects Jupyter code cells to be in a code-cell directive. This PR adds support for those.

## AI usage disclosure

As the commit shows, this is implemented by github copilot. I have reviewed the code, the tests, and adjusted the source reference.