### PR TITLE
Ignore whitespace before a line-ending ellipsis

### DIFF
--- a/docs/rest.rst
+++ b/docs/rest.rst
@@ -89,6 +89,10 @@ will pass, even though its actual output ends in a space:
 >>> print('See: ')
 See:
 
+When :data:`doctest.ELLIPSIS` is in use, whitespace before a line-ending ``...`` is
+also ignored, so expected output written as ``AssertionError: ...`` continues to match
+actual output of ``AssertionError:`` followed by a space and a newline.
+
 If you need trailing whitespace to be matched exactly, as the standard library's
 :mod:`doctest` module does, a :data:`~sybil.evaluators.doctest.KEEP_TRAILING_WHITESPACE`
 option flag is provided:

--- a/src/sybil/evaluators/doctest.py
+++ b/src/sybil/evaluators/doctest.py
@@ -38,6 +38,7 @@ def float_approx_equal(expected: str, actual: str, tolerance: float = 1e-12) -> 
 
 class OutputChecker(doctest.OutputChecker):
     _trailing_whitespace_re = re.compile(r'[ \t]+$', re.MULTILINE)
+    _whitespace_before_ellipsis_re = re.compile(r'[ \t]+(?=\.\.\.$)', re.MULTILINE)
 
     _number_re = re.compile(
         r"""
@@ -94,6 +95,10 @@ class OutputChecker(doctest.OutputChecker):
         if not optionflags & KEEP_TRAILING_WHITESPACE:
             want = self._trailing_whitespace_re.sub('', want)
             got = self._trailing_whitespace_re.sub('', got)
+            if optionflags & doctest.ELLIPSIS:
+                # Trailing whitespace in the actual output has been stripped above, so
+                # whitespace before a line-ending ellipsis could never match anything:
+                want = self._whitespace_before_ellipsis_re.sub('', want)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
     def output_difference(self, example: doctest.Example, got: str, optionflags: int) -> str:

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -267,6 +267,73 @@ def test_output_checker_trailing_whitespace():
     assert not checker.check_output('foo \n', 'foo\n', KEEP_TRAILING_WHITESPACE)
 
 
+@pytest.mark.parametrize(
+    ("want", "got", "optionflags", "matches"),
+    [
+        pytest.param(
+            'AssertionError: ...\nNot equal\n',
+            'AssertionError: \nNot equal\n',
+            ELLIPSIS,
+            True,
+            id='space-then-ellipsis-at-eol-matches-stripped-actual',
+        ),
+        pytest.param(
+            'Mismatched elements: 1 / 3 (33.3%)...\nMax difference: 0.5\n',
+            'Mismatched elements: 1 / 3 (33.3%)\nMax difference: 0.5\n',
+            ELLIPSIS,
+            True,
+            id='ellipsis-abutting-text-at-eol',
+        ),
+        pytest.param(
+            'Mismatched elements: 1 / 3 (33.3%)...\nMax difference: 0.5\n',
+            'Mismatched elements: 1 / 3 (33.3%) \nMax difference: 0.5\n',
+            ELLIPSIS,
+            True,
+            id='ellipsis-abutting-text-at-eol-with-trailing-whitespace-in-actual',
+        ),
+        pytest.param(
+            'foo ...\n',
+            'foo bar\n',
+            ELLIPSIS,
+            True,
+            id='space-then-ellipsis-still-matches-real-content',
+        ),
+        pytest.param(
+            'foo ...\n',
+            'foo ...\n',
+            0,
+            True,
+            id='literal-dots-without-ellipsis-flag-match-exactly',
+        ),
+        pytest.param(
+            'foo ...\n',
+            'foo bar\n',
+            0,
+            False,
+            id='literal-dots-without-ellipsis-flag-are-not-a-wildcard',
+        ),
+        pytest.param(
+            'AssertionError: ...\nNot equal\n',
+            'AssertionError: \nNot equal\n',
+            ELLIPSIS | KEEP_TRAILING_WHITESPACE,
+            True,
+            id='keep-flag-restores-space-matching-trailing-whitespace',
+        ),
+        pytest.param(
+            'AssertionError: ...\n',
+            'AssertionError:\n',
+            ELLIPSIS | KEEP_TRAILING_WHITESPACE,
+            False,
+            id='keep-flag-requires-space-before-ellipsis-to-be-present',
+        ),
+    ],
+)
+def test_output_checker_ellipsis_and_trailing_whitespace(
+    want: str, got: str, optionflags: int, matches: bool
+) -> None:
+    assert OutputChecker().check_output(want, got, optionflags) is matches
+
+
 # Number of doctests that can't be parsed in a file when looking at the whole file source:
 ROOT = Path(FUNCTIONAL_TEST_DIR)
 UNPARSEABLE = {


### PR DESCRIPTION
Default trailing whitespace stripping of actual output meant such whitespace in expected output could never match anything, breaking the 'text: ...' idiom found in existing projects' docs.